### PR TITLE
Cache regexes rather than building them anew on every use.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ path = "src/lib/mod.rs"
 [dependencies]
 bit-vec = "0.4.3"
 getopts = "0.2.14"
+lazy_static = "0.2.1"
 regex = "0.1.65"

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,5 +1,8 @@
 use std::fmt;
 
+#[macro_use]
+extern crate lazy_static;
+
 pub mod grammar;
 pub mod grammar_ast;
 pub mod yacc;

--- a/src/lib/yacc.rs
+++ b/src/lib/yacc.rs
@@ -50,6 +50,18 @@ impl fmt::Display for YaccError {
     }
 }
 
+lazy_static! {
+    static ref RE_NAME: Regex = {
+        Regex::new(r"^[a-zA-Z_.][a-zA-Z0-9_.]*").unwrap()
+    };
+    static ref RE_TERMINAL: Regex = {
+        Regex::new("^(?:(\".+?\")|('.+?')|([a-zA-Z_][a-zA-Z_0-9]*))").unwrap()
+    };
+    static ref RE_WHITESPACE: Regex = {
+        Regex::new(r"^\s+").unwrap()
+    };
+}
+
 /// The actual parser is intended to be entirely opaque from outside users.
 impl YaccParser {
     fn new(src: String) -> YaccParser {
@@ -183,8 +195,7 @@ impl YaccParser {
     }
 
     fn parse_name(&self, i: usize) -> YaccResult<(usize, String)> {
-        let re = Regex::new(r"^[a-zA-Z_.][a-zA-Z0-9_.]*").unwrap();
-        match re.find(&self.src[i..]) {
+        match RE_NAME.find(&self.src[i..]) {
             Some((s, e)) => {
                 assert!(s == 0);
                 Ok((i + e, self.src[i..i + e].to_string()))
@@ -194,8 +205,7 @@ impl YaccParser {
     }
 
     fn parse_terminal(&self, i: usize) -> YaccResult<(usize, String)> {
-        let re = Regex::new("^(?:(\".+?\")|('.+?')|([a-zA-Z_][a-zA-Z_0-9]*))").unwrap();
-        match re.find(&self.src[i..]) {
+        match RE_TERMINAL.find(&self.src[i..]) {
             Some((s, e)) => {
                 assert!(s == 0 && e > 0);
                 let first_char = self.src.chars().nth(i).unwrap();
@@ -211,8 +221,7 @@ impl YaccParser {
     }
 
     fn parse_ws(&self, i: usize) -> YaccResult<usize> {
-        let re = Regex::new(r"^\s+").unwrap();
-        match re.find(&self.src[i..]) {
+        match RE_WHITESPACE.find(&self.src[i..]) {
             Some((s, e)) => {
                 assert!(s == 0);
                 Ok(i + e)


### PR DESCRIPTION
This was previously particularly punishing on large grammars. With this commit, the PHP grammar takes under 0.5s to fully process, and is over 200x faster than Eco. So I think we're now fast enough.