### PR TITLE
Fix line reports

### DIFF
--- a/src/lib/yacc.rs
+++ b/src/lib/yacc.rs
@@ -77,15 +77,12 @@ impl YaccParser {
     }
 
     fn off_to_line_col(&self, off: usize) -> (usize, usize) {
-        if self.newlines.is_empty() {
-            return (1, off + 1);
-        }
-        for (line_m1, &line_off) in self.newlines.iter().enumerate() {
-            if line_off >= off {
-                return (line_m1 + 1, off - line_off + 1);
+        for (line_m1, &line_off) in self.newlines.iter().enumerate().rev() {
+            if line_off <= off {
+                return (line_m1 + 2, off - line_off);
             }
         }
-        (self.newlines.len() + 1, off - self.newlines.last().unwrap())
+        (1, off + 1)
     }
 
     fn parse(&mut self) -> YaccResult<usize> {
@@ -526,7 +523,8 @@ A:
 
     #[test]
     fn test_programs_not_supported() {
-        let src = "%% %% x".to_string();
+        let src = "%% %%
+x".to_string();
         match parse_yacc(&src) {
             Ok(_)  => panic!("Programs parsed"),
             Err(YaccError{kind: YaccErrorKind::ProgramsNotSupported, line: 1, col: 4}) => (),

--- a/src/lib/yacc.rs
+++ b/src/lib/yacc.rs
@@ -247,7 +247,7 @@ impl YaccParser {
         for c in self.src.chars().skip(i) {
             match c {
                 ' '  | '\t' => (),
-                '\n' | '\r' => self.newlines.push(i),
+                '\n' | '\r' => self.newlines.push(j),
                 _           => break
             }
             j += 1;
@@ -497,6 +497,18 @@ A:
         match parse_yacc(&src) {
             Ok(_)  => panic!("Incomplete rule parsed"),
             Err(YaccError{kind: YaccErrorKind::IncompleteRule, line: 3, col: 1}) => (),
+            Err(e) => panic!("Incorrect error returned {}", e)
+        }
+    }
+
+    #[test]
+    fn test_line_col_report3() {
+        let src = "
+        
+        %woo".to_string();
+        match parse_yacc(&src) {
+            Ok(_)  => panic!("Incomplete rule parsed"),
+            Err(YaccError{kind: YaccErrorKind::UnknownDeclaration, line: 3, col: 9}) => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
     }


### PR DESCRIPTION
This fixes two bugs in reporting where errors occur in an LR grammar. The first commit avoids this happening:

```
        thread 'yacc::test::test_programs_not_supported' panicked at 'attempt to subtract with overflow', src/lib/yacc.rs:85


failures:
    yacc::test::test_programs_not_supported
```