### PR TITLE
Expose some internals needed by lrpar.

### DIFF
--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -69,6 +69,18 @@ pub enum AssocKind {
     Nonassoc
 }
 
+impl Grammar {
+    /// Return the rule index of the production `i`.
+    pub fn prod_to_rule_idx(&self, i: PIdx) -> RIdx {
+        for (j, rule) in self.rules_prods.iter().enumerate() {
+            if rule.iter().position(|x| *x == i).is_some() {
+                return j;
+            }
+        }
+        panic!("Invalid index {}", i);
+    }
+}
+
 #[cfg(test)]
 impl Grammar {
     /// Map a nonterminal name to the corresponding rule offset.

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -9,11 +9,10 @@ mod yacc;
 mod stategraph;
 pub mod statetable;
 
-pub use grammar::ast_to_grammar;
-use grammar::Grammar;
+pub use grammar::{ast_to_grammar, Grammar, RIdx, Symbol};
 pub use grammar_ast::{GrammarAST, GrammarASTError};
 use stategraph::StateGraph;
-use statetable::StateTable;
+pub use statetable::{Action, StateTable};
 pub use yacc::{YaccError, YaccErrorKind};
 use yacc::parse_yacc;
 


### PR DESCRIPTION
Chiefly a simple way of getting a rule index from a production index.