### PR TITLE
Lockdown, and make more consistent, the external API.

### DIFF
--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -46,7 +46,7 @@ pub struct Grammar {
     /// A mapping from TIdx -> String.
     pub terminal_names: Vec<String>,
     /// A mapping from TIdx -> Option<Precedence>
-    pub terminal_precs: Vec<Option<Precedence>>,
+    terminal_precs: Vec<Option<Precedence>>,
     pub terms_len: usize,
     /// Which production is the sole production of the start rule?
     pub start_prod: PIdx,
@@ -217,6 +217,11 @@ impl Grammar {
     /// Return the rule name for rule `i`.
     pub fn get_rule_name(&self, i: RIdx) -> Option<&str> {
         self.nonterminal_names.get(usize::from(i)).map_or(None, |x| Some(&x))
+    }
+
+    /// Return the precedence of terminal `i`.
+    pub fn term_precedence(&self, i: TIdx) -> Option<Option<Precedence>> {
+        self.terminal_precs.get(usize::from(i)).map_or(None, |x| Some(*x))
     }
 }
 

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -41,7 +41,7 @@ custom_derive! {
 
 pub struct Grammar {
     /// A mapping from RIdx -> String.
-    pub nonterminal_names: Vec<String>,
+    nonterminal_names: Vec<String>,
     pub nonterms_len: usize,
     /// A mapping from TIdx -> String.
     terminal_names: Vec<String>,

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -206,8 +206,9 @@ impl Grammar {
         self.prods.len()
     }
 
-    pub fn get_rule_name(&self, i: RIdx) -> Option<&String> {
-        self.nonterminal_names.get(usize::from(i))
+    /// Return the rule name for rule `i`.
+    pub fn get_rule_name(&self, i: RIdx) -> Option<&str> {
+        self.nonterminal_names.get(usize::from(i)).map_or(None, |x| Some(&x))
     }
 }
 

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -197,8 +197,9 @@ impl Grammar {
         panic!("Invalid index {:?}", i);
     }
 
-    pub fn get_prod(&self, i: PIdx) -> Option<&Vec<Symbol>> {
-        self.prods.get(usize::from(i))
+    /// Get the sequence of symbols for production `i`.
+    pub fn get_prod(&self, i: PIdx) -> Option<&[Symbol]> {
+        self.prods.get(usize::from(i)).map_or(None, |x| Some(x))
     }
 
     pub fn prods_len(&self) -> usize {
@@ -253,9 +254,9 @@ mod test {
 
         assert_eq!(grm.rules_prods, vec![vec![PIdx(0)], vec![PIdx(1)]]);
         let start_prod = grm.get_prod(grm.rules_prods[usize::from(grm.nonterminal_off("^"))][0]).unwrap();
-        assert_eq!(*start_prod, vec![Symbol::Nonterminal(grm.nonterminal_off("R"))]);
+        assert_eq!(*start_prod, [Symbol::Nonterminal(grm.nonterminal_off("R"))]);
         let r_prod = grm.get_prod(grm.rules_prods[usize::from(grm.nonterminal_off("R"))][0]).unwrap();
-        assert_eq!(*r_prod, vec![Symbol::Terminal(grm.terminal_off("T"))]);
+        assert_eq!(*r_prod, [Symbol::Terminal(grm.terminal_off("T"))]);
     }
 
     #[test]
@@ -271,7 +272,7 @@ mod test {
 
         assert_eq!(grm.rules_prods, vec![vec![PIdx(0)], vec![PIdx(1)], vec![PIdx(2)]]);
         let start_prod = grm.get_prod(grm.rules_prods[usize::from(grm.nonterminal_off("^"))][0]).unwrap();
-        assert_eq!(*start_prod, vec![Symbol::Nonterminal(grm.nonterminal_off("R"))]);
+        assert_eq!(*start_prod, [Symbol::Nonterminal(grm.nonterminal_off("R"))]);
         let r_prod = grm.get_prod(grm.rules_prods[usize::from(grm.nonterminal_off("R"))][0]).unwrap();
         assert_eq!(r_prod.len(), 1);
         assert_eq!(r_prod[0], Symbol::Nonterminal(grm.nonterminal_off("S")));
@@ -294,7 +295,7 @@ mod test {
 
         assert_eq!(grm.rules_prods, vec![vec![PIdx(0)], vec![PIdx(1)], vec![PIdx(2)]]);
         let start_prod = grm.get_prod(grm.rules_prods[usize::from(grm.nonterminal_off("^"))][0]).unwrap();
-        assert_eq!(*start_prod, vec![Symbol::Nonterminal(grm.nonterminal_off("R"))]);
+        assert_eq!(*start_prod, [Symbol::Nonterminal(grm.nonterminal_off("R"))]);
         let r_prod = grm.get_prod(grm.rules_prods[usize::from(grm.nonterminal_off("R"))][0]).unwrap();
         assert_eq!(r_prod.len(), 3);
         assert_eq!(r_prod[0], Symbol::Nonterminal(grm.nonterminal_off("S")));

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -60,7 +60,7 @@ pub struct Grammar {
     prods_rules: Vec<RIdx>,
     /// A list of all productions.
     prods: Vec<Vec<Symbol>>,
-    pub prod_precs: Vec<Option<Precedence>>
+    prod_precs: Vec<Option<Precedence>>
 }
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
@@ -217,6 +217,11 @@ impl Grammar {
     /// Return the rule name for rule `i`.
     pub fn get_rule_name(&self, i: RIdx) -> Option<&str> {
         self.nonterminal_names.get(usize::from(i)).map_or(None, |x| Some(&x))
+    }
+
+    /// Return the precedence of production `i`.
+    pub fn prod_precedence(&self, i: PIdx) -> Option<Option<Precedence>> {
+        self.prod_precs.get(usize::from(i)).map_or(None, |x| Some(*x))
     }
 
     /// Return the precedence of terminal `i`.

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -194,17 +194,17 @@ impl Grammar {
         }
     }
 
-    /// Return the productions for rule `i`.
+    /// Return the productions for rule `i` or None if it doesn't exist.
     pub fn rule_idx_to_prods(&self, i: RIdx) -> Option<&[PIdx]> {
         self.rules_prods.get(usize::from(i)).map_or(None, |x| Some(x))
     }
 
-    /// Return the rule index of the production `i`.
+    /// Return the rule index of the production `i` or None if it doesn't exist.
     pub fn prod_to_rule_idx(&self, i: PIdx) -> RIdx {
         self.prods_rules[usize::from(i)]
     }
 
-    /// Get the sequence of symbols for production `i`.
+    /// Get the sequence of symbols for production `i` or None if it doesn't exist.
     pub fn get_prod(&self, i: PIdx) -> Option<&[Symbol]> {
         self.prods.get(usize::from(i)).map_or(None, |x| Some(x))
     }
@@ -214,17 +214,17 @@ impl Grammar {
         self.prods.len()
     }
 
-    /// Return the rule name for rule `i`.
+    /// Return the rule name for rule `i` or None if it doesn't exist.
     pub fn get_rule_name(&self, i: RIdx) -> Option<&str> {
         self.nonterminal_names.get(usize::from(i)).map_or(None, |x| Some(&x))
     }
 
-    /// Return the precedence of production `i`.
+    /// Return the precedence of production `i` or None if it doesn't exist.
     pub fn prod_precedence(&self, i: PIdx) -> Option<Option<Precedence>> {
         self.prod_precs.get(usize::from(i)).map_or(None, |x| Some(*x))
     }
 
-    /// Return the precedence of terminal `i`.
+    /// Return the precedence of terminal `i` or None if it doesn't exist.
     pub fn term_precedence(&self, i: TIdx) -> Option<Option<Precedence>> {
         self.terminal_precs.get(usize::from(i)).map_or(None, |x| Some(*x))
     }

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -268,7 +268,7 @@ impl Grammar {
 
 #[cfg(test)]
 mod test {
-    use super::{AssocKind, Grammar, PIdx, NTIdx, Precedence, Symbol};
+    use super::{AssocKind, Grammar, NTIdx, PIdx, Precedence, Symbol, TIdx};
     use yacc_parser::parse_yacc;
 
     #[test]
@@ -288,6 +288,9 @@ mod test {
         let r_prod = grm.prod(grm.rules_prods[usize::from(grm.nonterminal_off("R"))][0]).unwrap();
         assert_eq!(*r_prod, [Symbol::Terminal(grm.terminal_off("T"))]);
         assert_eq!(grm.prods_rules, vec![NTIdx(0), NTIdx(1)]);
+
+        assert_eq!(grm.iter_term_idxs().collect::<Vec<TIdx>>(), vec![TIdx(0), TIdx(1)]);
+        assert_eq!(grm.iter_nonterm_idxs().collect::<Vec<NTIdx>>(), vec![NTIdx(0), NTIdx(1)]);
     }
 
     #[test]

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -60,6 +60,7 @@ pub struct Grammar {
     prods_rules: Vec<RIdx>,
     /// A list of all productions.
     prods: Vec<Vec<Symbol>>,
+    /// The precedence of each production.
     prod_precs: Vec<Option<Precedence>>
 }
 

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -41,18 +41,22 @@ custom_derive! {
 }
 
 pub struct Grammar {
+    /// How many nonterminals does this grammar have?
+    pub nonterms_len: usize,
     /// A mapping from NTIdx -> String.
     nonterminal_names: Vec<String>,
-    pub nonterms_len: usize,
     /// A mapping from TIdx -> String.
     terminal_names: Vec<String>,
     /// A mapping from TIdx -> Option<Precedence>
     terminal_precs: Vec<Option<Precedence>>,
+    /// How many terminals does this grammar have?
     pub terms_len: usize,
-    /// Which production is the sole production of the start rule?
-    pub start_prod: PIdx,
     /// The offset of the EOF terminal.
     pub end_term: TIdx,
+    /// How many productions does this grammar have?
+    pub prods_len: usize,
+    /// Which production is the sole production of the start rule?
+    pub start_prod: PIdx,
     /// A list of all productions.
     prods: Vec<Vec<Symbol>>,
     /// A mapping from rules to their productions. Note that 2) the order of rules is identical to
@@ -185,10 +189,11 @@ impl Grammar {
             nonterms_len:      nonterm_names.len(),
             nonterminal_names: nonterm_names,
             terms_len:         term_names.len(),
+            end_term:          terminal_map[&end_term],
             terminal_names:    term_names,
             terminal_precs:    term_precs,
+            prods_len:         prods.len(),
             start_prod:        rules_prods[usize::from(nonterm_map[&start_nonterm])][0],
-            end_term:          terminal_map[&end_term],
             rules_prods:       rules_prods,
             prods_rules:       prods_rules,
             prods:             prods,
@@ -209,11 +214,6 @@ impl Grammar {
     /// Return an iterator which produces (in no particular order) all this grammar's valid NTIdxs.
     pub fn iter_nonterm_idxs(&self) -> Box<Iterator<Item=NTIdx>> {
         Box::new((0..self.nonterms_len).map(|x| NTIdx(x)))
-    }
-
-    /// How many productions does this grammar have?
-    pub fn prods_len(&self) -> usize {
-        self.prods.len()
     }
 
     /// Get the sequence of symbols for production `i` or None if it doesn't exist.

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -226,15 +226,9 @@ impl Grammar {
         TIdx(self.terminal_names.iter().position(|x| x == n).unwrap())
     }
 
-    /// Map a production number to a rule name. Note: this has a worst case of O(n * m) where n is
-    /// the number of rules in the grammar and m the total number of productions.
-    pub fn prod_to_term_name(&self, i: PIdx) -> String {
-        for (j, rule) in self.rules_prods.iter().enumerate() {
-            if rule.iter().position(|x| *x == i).is_some() {
-                return self.nonterminal_names[j].clone();
-            }
-        }
-        panic!("Invalid index {}", usize::from(i));
+    /// Map a production number to a rule name.
+    pub fn prod_to_term_name(&self, i: PIdx) -> &str {
+        &self.nonterminal_names[usize::from(self.prod_to_rule_idx(i))]
     }
 }
 

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -55,7 +55,7 @@ pub struct Grammar {
     /// A mapping from rules to their productions. Note that 2) the order of rules is identical to
     /// that of `nonterminal_names' 2) every rule will have at least 1 production 3) productions
     /// are not necessarily stored sequentially.
-    pub rules_prods: Vec<Vec<PIdx>>,
+    rules_prods: Vec<Vec<PIdx>>,
     /// A mapping from productions to their corresponding rule indexes.
     prods_rules: Vec<RIdx>,
     /// A list of all productions.
@@ -194,6 +194,11 @@ impl Grammar {
         }
     }
 
+    /// Return the productions for rule `i`.
+    pub fn rule_idx_to_prods(&self, i: RIdx) -> Option<&[PIdx]> {
+        self.rules_prods.get(usize::from(i)).map_or(None, |x| Some(x))
+    }
+
     /// Return the rule index of the production `i`.
     pub fn prod_to_rule_idx(&self, i: PIdx) -> RIdx {
         self.prods_rules[usize::from(i)]
@@ -204,6 +209,7 @@ impl Grammar {
         self.prods.get(usize::from(i)).map_or(None, |x| Some(x))
     }
 
+    /// How many productions does this grammar have?
     pub fn prods_len(&self) -> usize {
         self.prods.len()
     }

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -44,7 +44,7 @@ pub struct Grammar {
     pub nonterminal_names: Vec<String>,
     pub nonterms_len: usize,
     /// A mapping from TIdx -> String.
-    pub terminal_names: Vec<String>,
+    terminal_names: Vec<String>,
     /// A mapping from TIdx -> Option<Precedence>
     terminal_precs: Vec<Option<Precedence>>,
     pub terms_len: usize,
@@ -224,9 +224,19 @@ impl Grammar {
         self.prod_precs.get(usize::from(i)).map_or(None, |x| Some(*x))
     }
 
+    /// Return the name of terminal `i` or None if it doesn't exist.
+    pub fn term_name(&self, i: TIdx) -> Option<&str> {
+        self.terminal_names.get(usize::from(i)).map_or(None, |x| Some(&x))
+    }
+
     /// Return the precedence of terminal `i` or None if it doesn't exist.
     pub fn term_precedence(&self, i: TIdx) -> Option<Option<Precedence>> {
         self.terminal_precs.get(usize::from(i)).map_or(None, |x| Some(*x))
+    }
+
+    /// Return an iterator which produces (in no particular order) all this grammar's valid TIdxs.
+    pub fn iter_term_idxs(&self) -> Box<Iterator<Item=TIdx>> {
+        Box::new((0..self.terms_len).map(|x| TIdx(x)))
     }
 }
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -11,7 +11,7 @@ mod yacc_parser;
 mod stategraph;
 pub mod statetable;
 
-pub use grammar::{Grammar, PIdx, RIdx, Symbol, TIdx};
+pub use grammar::{Grammar, PIdx, NTIdx, Symbol, TIdx};
 pub use ast::{GrammarAST, GrammarValidationError};
 use stategraph::StateGraph;
 pub use statetable::{Action, StateTable};

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -18,6 +18,12 @@ pub use statetable::{Action, StateTable};
 pub use yacc_parser::{YaccParserError, YaccParserErrorKind};
 use yacc_parser::parse_yacc;
 
+custom_derive! {
+    /// A type specifically for state indexes.
+    #[derive(Clone, Copy, Debug, Eq, Hash, NewtypeFrom, PartialEq)]
+    pub struct StIdx(usize);
+}
+
 #[derive(Debug)]
 pub enum YaccToStateTableError {
     YaccParserError(YaccParserError),

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -224,7 +224,7 @@ impl Itemset {
 
         let mut keys_iter = self.items.keys(); // The initial todo list
         type BitVecBitSize = u32; // As of 0.4.3, BitVec only supports u32 blocks
-        let mut zero_todos = BitVec::<BitVecBitSize>::from_elem(grm.prods_len(), false); // Subsequent todos
+        let mut zero_todos = BitVec::<BitVecBitSize>::from_elem(grm.prods_len, false); // Subsequent todos
         let mut new_ctx = BitVec::from_elem(grm.terms_len, false);
         loop {
             let prod_i;

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -84,7 +84,7 @@ impl Firsts {
         // have new elements in since we last looked. If they do, we'll have to do another round.
         loop {
             let mut changed = false;
-            for rul_i in (0..grm.nonterms_len).map(|x| NTIdx::from(x)) {
+            for rul_i in grm.iter_nonterm_idxs() {
                 // For each rule E
                 for prod_i in grm.nonterm_to_prods(rul_i).unwrap().iter() {
                     // ...and each production A
@@ -112,9 +112,9 @@ impl Firsts {
                                 // together with the current nonterminals FIRSTs. Note this is
                                 // (intentionally) a no-op if the two terminals are one and the
                                 // same.
-                                for bit_i in 0..grm.terms_len {
-                                    if firsts.is_set(nonterm_i, TIdx::from(bit_i))
-                                      && !firsts.set(rul_i, TIdx::from(bit_i)) {
+                                for term_idx in grm.iter_term_idxs() {
+                                    if firsts.is_set(nonterm_i, term_idx)
+                                      && !firsts.set(rul_i, term_idx) {
                                         changed = true;
                                     }
                                 }

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -8,7 +8,7 @@ use self::bit_vec::{BitBlock, BitVec};
 extern crate fnv;
 use self::fnv::FnvHasher;
 
-use grammar::{PIdx, Grammar, RIdx, Symbol, SIdx, TIdx};
+use grammar::{PIdx, Grammar, NTIdx, Symbol, SIdx, TIdx};
 
 // This file creates stategraphs from grammars. Unfortunately there is no perfect guide to how to
 // do this that I know of -- certainly not one that talks about sensible ways to arrange data and
@@ -83,7 +83,7 @@ impl Firsts {
         // have new elements in since we last looked. If they do, we'll have to do another round.
         loop {
             let mut changed = false;
-            for rul_i in (0..grm.nonterms_len).map(|x| RIdx::from(x)) {
+            for rul_i in (0..grm.nonterms_len).map(|x| NTIdx::from(x)) {
                 // For each rule E
                 for prod_i in grm.rule_idx_to_prods(rul_i).unwrap().iter() {
                     // ...and each production A
@@ -91,7 +91,7 @@ impl Firsts {
                     if prod.is_empty() {
                         // if it's an empty production, ensure this nonterminal's epsilon bit is
                         // set.
-                        if !firsts.is_epsilon_set(RIdx::from(rul_i)) {
+                        if !firsts.is_epsilon_set(NTIdx::from(rul_i)) {
                             firsts.prod_epsilons.set(usize::from(rul_i), true);
                             changed = true;
                         }
@@ -145,23 +145,23 @@ impl Firsts {
     }
 
     /// Returns true if the terminal `tidx` is in the first set for nonterminal `nidx` is set.
-    fn is_set(&self, nidx: RIdx, tidx: TIdx) -> bool {
+    fn is_set(&self, nidx: NTIdx, tidx: TIdx) -> bool {
         self.prod_firsts[usize::from(nidx)][usize::from(tidx)]
     }
 
     /// Get all the firsts for production `nidx` as a `Ctx`.
-    fn prod_firsts(&self, nidx: RIdx) -> &Ctx {
+    fn prod_firsts(&self, nidx: NTIdx) -> &Ctx {
         &self.prod_firsts[usize::from(usize::from(nidx))]
     }
 
     /// Returns true if the nonterminal `nidx` has epsilon in its first set.
-    fn is_epsilon_set(&self, nidx: RIdx) -> bool {
+    fn is_epsilon_set(&self, nidx: NTIdx) -> bool {
         self.prod_epsilons[usize::from(usize::from(nidx))]
     }
 
     /// Ensures that the firsts bit for terminal `tidx` nonterminal `nidx` is set. Returns true if
     /// it was already set, or false otherwise.
-    fn set(&mut self, nidx: RIdx, tidx: TIdx) -> bool {
+    fn set(&mut self, nidx: NTIdx, tidx: TIdx) -> bool {
         let mut prod = &mut self.prod_firsts[usize::from(nidx)];
         if prod[usize::from(tidx)] {
             true

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -642,8 +642,9 @@ mod test {
 
     fn has(grm: &Grammar, firsts: &Firsts, rn: &str, should_be: Vec<&str>) {
         let nt_i = grm.nonterminal_off(rn);
-        for (i, n) in grm.terminal_names.iter().enumerate() {
-            match should_be.iter().position(|x| x == n) {
+        for i in 0 .. grm.terms_len {
+            let n = grm.term_name(TIdx::from(i)).unwrap();
+            match should_be.iter().position(|&x| x == n) {
                 Some(_) => {
                     if !firsts.is_set(nt_i, TIdx::from(i)) {
                         panic!("{} is not set in {}", n, rn);
@@ -814,7 +815,7 @@ mod test {
             }
             if !found && bit {
                 panic!("bit for terminal {}, dot {} is set in production {} of {} when it shouldn't be",
-                       grm.terminal_names[i], dot, prod_off, nt);
+                       grm.term_name(TIdx::from(i)).unwrap(), dot, prod_off, nt);
             }
         }
     }
@@ -822,7 +823,6 @@ mod test {
     fn num_active_states(is: &Itemset) -> usize {
         is.items.len()
     }
-
 
     #[test]
     fn test_dragon_grammar() {

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -108,7 +108,7 @@ fn resolve_shift_reduce(grm: &Grammar, mut e: OccupiedEntry<(usize, Symbol), Act
                         prod_k: PIdx, state_j: usize) -> u64 {
     let mut shift_reduce = 0;
     let term_k_prec = grm.term_precedence(term_k).unwrap();
-    let prod_k_prec = grm.prod_precs[usize::from(prod_k)];
+    let prod_k_prec = grm.prod_precedence(prod_k).unwrap();
     match (term_k_prec, prod_k_prec) {
         (_, None) | (None, _) => {
             // If the terminal and production don't both have precedences, we use Yacc's default

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -1,6 +1,6 @@
 use std::collections::hash_map::{Entry, HashMap, OccupiedEntry};
 
-use grammar::{AssocKind, Grammar, PIdx, RIdx, SIdx, Symbol, TIdx};
+use grammar::{AssocKind, Grammar, PIdx, NTIdx, SIdx, Symbol, TIdx};
 use stategraph::StateGraph;
 
 /// A representation of a `StateTable` for a grammar. `actions` and `gotos` are split into two
@@ -8,7 +8,7 @@ use stategraph::StateGraph;
 #[derive(Debug)]
 pub struct StateTable {
     pub actions      : HashMap<(usize, Symbol), Action>,
-    pub gotos        : HashMap<(usize, RIdx), usize>,
+    pub gotos        : HashMap<(usize, NTIdx), usize>,
     /// The number of reduce/reduce errors encountered.
     pub reduce_reduce: u64,
     /// The number of shift/reduce errors encountered.
@@ -28,7 +28,7 @@ pub enum Action {
 impl StateTable {
     pub fn new(grm: &Grammar, sg: &StateGraph) -> StateTable {
         let mut actions: HashMap<(usize, Symbol), Action> = HashMap::new();
-        let mut gotos  : HashMap<(usize, RIdx), usize>    = HashMap::new();
+        let mut gotos  : HashMap<(usize, NTIdx), usize>    = HashMap::new();
         let mut reduce_reduce = 0; // How many automatically resolved reduce/reduces were made?
         let mut shift_reduce  = 0; // How many automatically resolved shift/reduces were made?
 

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -107,7 +107,7 @@ impl StateTable {
 fn resolve_shift_reduce(grm: &Grammar, mut e: OccupiedEntry<(usize, Symbol), Action>, term_k: TIdx,
                         prod_k: PIdx, state_j: usize) -> u64 {
     let mut shift_reduce = 0;
-    let term_k_prec = grm.terminal_precs[usize::from(term_k)];
+    let term_k_prec = grm.term_precedence(term_k).unwrap();
     let prod_k_prec = grm.prod_precs[usize::from(prod_k)];
     match (term_k_prec, prod_k_prec) {
         (_, None) | (None, _) => {

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -8,15 +8,15 @@ use stategraph::StateGraph;
 /// separate hashmaps, rather than a single table, due to the different types of their values.
 #[derive(Debug)]
 pub struct StateTable {
-    pub actions      : HashMap<(StIdx, Symbol), Action>,
-    pub gotos        : HashMap<(StIdx, NTIdx), StIdx>,
+    actions          : HashMap<(StIdx, Symbol), Action>,
+    gotos            : HashMap<(StIdx, NTIdx), StIdx>,
     /// The number of reduce/reduce errors encountered.
     pub reduce_reduce: u64,
     /// The number of shift/reduce errors encountered.
     pub shift_reduce : u64
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Action {
     /// Shift to state X in the statetable.
     Shift(StIdx),
@@ -103,6 +103,15 @@ impl StateTable {
                      shift_reduce: shift_reduce }
     }
 
+    /// Return the action for `state_idx` and `sym`, or None if there isn't any.
+    pub fn action(&self, state_idx: StIdx, sym: Symbol) -> Option<Action> {
+        self.actions.get(&(state_idx, sym)).map_or(None, |x| Some(*x))
+    }
+
+    /// Return the goto state for `state_idx` and `nonterm_idx`, or None if there isn't any.
+    pub fn goto(&self, state_idx: StIdx, nonterm_idx: NTIdx) -> Option<StIdx> {
+        self.gotos.get(&(state_idx, nonterm_idx)).map_or(None, |x| Some(*x))
+    }
 }
 
 fn resolve_shift_reduce(grm: &Grammar, mut e: OccupiedEntry<(StIdx, Symbol), Action>, term_k: TIdx,

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -184,7 +184,7 @@ mod test {
         // Actions
         assert_eq!(st.actions.len(), 15);
         let assert_reduce = |state_i: usize, term_i: TIdx, rule: &str, prod_off: usize| {
-            let prod_i = grm.rules_prods[usize::from(grm.nonterminal_off(rule))][prod_off];
+            let prod_i = grm.rule_idx_to_prods(grm.nonterminal_off(rule)).unwrap()[prod_off];
             assert_eq!(st.actions[&(state_i, Symbol::Terminal(term_i))], Action::Reduce(PIdx::from(prod_i)));
         };
 

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -35,7 +35,7 @@ impl StateTable {
         for (state_i, state) in sg.states.iter().enumerate() {
             // Populate reduce and accepts
             for (&(prod_i, dot), ctx) in &state.items {
-                if dot < SIdx::from(grm.get_prod(prod_i).unwrap().len()) {
+                if dot < SIdx::from(grm.prod(prod_i).unwrap().len()) {
                     continue;
                 }
                 for (term_i, _) in ctx.iter().enumerate().filter(|&(_, x)| x) {
@@ -184,7 +184,7 @@ mod test {
         // Actions
         assert_eq!(st.actions.len(), 15);
         let assert_reduce = |state_i: usize, term_i: TIdx, rule: &str, prod_off: usize| {
-            let prod_i = grm.rule_idx_to_prods(grm.nonterminal_off(rule)).unwrap()[prod_off];
+            let prod_i = grm.nonterm_to_prods(grm.nonterminal_off(rule)).unwrap()[prod_off];
             assert_eq!(st.actions[&(state_i, Symbol::Terminal(term_i))], Action::Reduce(PIdx::from(prod_i)));
         };
 

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -1,5 +1,6 @@
 use std::collections::hash_map::{Entry, HashMap, OccupiedEntry};
 
+use StIdx;
 use grammar::{AssocKind, Grammar, PIdx, NTIdx, SIdx, Symbol, TIdx};
 use stategraph::StateGraph;
 
@@ -7,8 +8,8 @@ use stategraph::StateGraph;
 /// separate hashmaps, rather than a single table, due to the different types of their values.
 #[derive(Debug)]
 pub struct StateTable {
-    pub actions      : HashMap<(usize, Symbol), Action>,
-    pub gotos        : HashMap<(usize, NTIdx), usize>,
+    pub actions      : HashMap<(StIdx, Symbol), Action>,
+    pub gotos        : HashMap<(StIdx, NTIdx), StIdx>,
     /// The number of reduce/reduce errors encountered.
     pub reduce_reduce: u64,
     /// The number of shift/reduce errors encountered.
@@ -18,7 +19,7 @@ pub struct StateTable {
 #[derive(Debug, PartialEq)]
 pub enum Action {
     /// Shift to state X in the statetable.
-    Shift(usize),
+    Shift(StIdx),
     /// Reduce production X in the grammar.
     Reduce(PIdx),
     /// Accept this input.
@@ -27,12 +28,12 @@ pub enum Action {
 
 impl StateTable {
     pub fn new(grm: &Grammar, sg: &StateGraph) -> StateTable {
-        let mut actions: HashMap<(usize, Symbol), Action> = HashMap::new();
-        let mut gotos  : HashMap<(usize, NTIdx), usize>    = HashMap::new();
+        let mut actions: HashMap<(StIdx, Symbol), Action> = HashMap::new();
+        let mut gotos  : HashMap<(StIdx, NTIdx), StIdx>   = HashMap::new();
         let mut reduce_reduce = 0; // How many automatically resolved reduce/reduces were made?
         let mut shift_reduce  = 0; // How many automatically resolved shift/reduces were made?
 
-        for (state_i, state) in sg.states.iter().enumerate() {
+        for (state_i, state) in sg.states.iter().enumerate().map(|(x, y)| (StIdx(x), y)) {
             // Populate reduce and accepts
             for (&(prod_i, dot), ctx) in &state.items {
                 if dot < SIdx::from(grm.prod(prod_i).unwrap().len()) {
@@ -69,7 +70,7 @@ impl StateTable {
                 }
             }
 
-            for (&sym, state_j) in &sg.edges[state_i] {
+            for (&sym, state_j) in &sg.edges[usize::from(state_i)] {
                 match sym {
                     Symbol::Nonterminal(nonterm_i) => {
                         // Populate gotos
@@ -104,8 +105,8 @@ impl StateTable {
 
 }
 
-fn resolve_shift_reduce(grm: &Grammar, mut e: OccupiedEntry<(usize, Symbol), Action>, term_k: TIdx,
-                        prod_k: PIdx, state_j: usize) -> u64 {
+fn resolve_shift_reduce(grm: &Grammar, mut e: OccupiedEntry<(StIdx, Symbol), Action>, term_k: TIdx,
+                        prod_k: PIdx, state_j: StIdx) -> u64 {
     let mut shift_reduce = 0;
     let term_k_prec = grm.term_precedence(term_k).unwrap();
     let prod_k_prec = grm.prod_precedence(prod_k).unwrap();
@@ -151,6 +152,7 @@ fn resolve_shift_reduce(grm: &Grammar, mut e: OccupiedEntry<(usize, Symbol), Act
 
 #[cfg(test)]
 mod test {
+    use StIdx;
     use super::{Action, StateTable};
     use stategraph::StateGraph;
     use grammar::{Grammar, PIdx, Symbol, TIdx};
@@ -169,21 +171,21 @@ mod test {
         let sg = StateGraph::new(&grm);
         assert_eq!(sg.states.len(), 9);
 
-        let s0 = 0;
-        let s1 = sg.edges[s0][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s2 = sg.edges[s0][&Symbol::Nonterminal(grm.nonterminal_off("Term"))];
-        let s3 = sg.edges[s0][&Symbol::Nonterminal(grm.nonterminal_off("Factor"))];
-        let s4 = sg.edges[s0][&Symbol::Terminal(grm.terminal_off("id"))];
-        let s5 = sg.edges[s2][&Symbol::Terminal(grm.terminal_off("-"))];
-        let s6 = sg.edges[s3][&Symbol::Terminal(grm.terminal_off("*"))];
-        let s7 = sg.edges[s5][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s8 = sg.edges[s6][&Symbol::Nonterminal(grm.nonterminal_off("Term"))];
+        let s0 = StIdx(0);
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s2 = sg.edges[usize::from(s0)][&Symbol::Nonterminal(grm.nonterminal_off("Term"))];
+        let s3 = sg.edges[usize::from(s0)][&Symbol::Nonterminal(grm.nonterminal_off("Factor"))];
+        let s4 = sg.edges[usize::from(s0)][&Symbol::Terminal(grm.terminal_off("id"))];
+        let s5 = sg.edges[usize::from(s2)][&Symbol::Terminal(grm.terminal_off("-"))];
+        let s6 = sg.edges[usize::from(s3)][&Symbol::Terminal(grm.terminal_off("*"))];
+        let s7 = sg.edges[usize::from(s5)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s8 = sg.edges[usize::from(s6)][&Symbol::Nonterminal(grm.nonterminal_off("Term"))];
 
         let st = StateTable::new(&grm, &sg);
 
         // Actions
         assert_eq!(st.actions.len(), 15);
-        let assert_reduce = |state_i: usize, term_i: TIdx, rule: &str, prod_off: usize| {
+        let assert_reduce = |state_i: StIdx, term_i: TIdx, rule: &str, prod_off: usize| {
             let prod_i = grm.nonterm_to_prods(grm.nonterminal_off(rule)).unwrap()[prod_off];
             assert_eq!(st.actions[&(state_i, Symbol::Terminal(term_i))], Action::Reduce(PIdx::from(prod_i)));
         };
@@ -230,8 +232,8 @@ mod test {
         assert_eq!(st.actions.len(), 8);
 
         // We only extract the states necessary to test those rules affected by the reduce/reduce.
-        let s0 = 0;
-        let s4 = sg.edges[s0][&Symbol::Terminal(grm.terminal_off("a"))];
+        let s0 = StIdx(0);
+        let s4 = sg.edges[usize::from(s0)][&Symbol::Terminal(grm.terminal_off("a"))];
 
         assert_eq!(st.actions[&(s4, Symbol::Terminal(grm.terminal_off("x")))], Action::Reduce(PIdx::from(3)));
     }
@@ -249,12 +251,12 @@ mod test {
         let st = StateTable::new(&grm, &sg);
         assert_eq!(st.actions.len(), 15);
 
-        let s0 = 0;
-        let s1 = sg.edges[s0][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s3 = sg.edges[s1][&Symbol::Terminal(grm.terminal_off("+"))];
-        let s4 = sg.edges[s1][&Symbol::Terminal(grm.terminal_off("*"))];
-        let s5 = sg.edges[s4][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s6 = sg.edges[s3][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s0 = StIdx(0);
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Terminal(grm.terminal_off("+"))];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Terminal(grm.terminal_off("*"))];
+        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s6 = sg.edges[usize::from(s3)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
 
         assert_eq!(st.actions[&(s5, Symbol::Terminal(grm.terminal_off("+")))], Action::Shift(s3));
         assert_eq!(st.actions[&(s5, Symbol::Terminal(grm.terminal_off("*")))], Action::Shift(s4));
@@ -278,12 +280,12 @@ mod test {
         let st = StateTable::new(&grm, &sg);
         assert_eq!(st.actions.len(), 15);
 
-        let s0 = 0;
-        let s1 = sg.edges[s0][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s3 = sg.edges[s1][&Symbol::Terminal(grm.terminal_off("+"))];
-        let s4 = sg.edges[s1][&Symbol::Terminal(grm.terminal_off("*"))];
-        let s5 = sg.edges[s4][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s6 = sg.edges[s3][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s0 = StIdx(0);
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Terminal(grm.terminal_off("+"))];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Terminal(grm.terminal_off("*"))];
+        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s6 = sg.edges[usize::from(s3)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
 
         assert_eq!(st.actions[&(s5, Symbol::Terminal(grm.terminal_off("+")))], Action::Reduce(PIdx::from(2)));
         assert_eq!(st.actions[&(s5, Symbol::Terminal(grm.terminal_off("*")))], Action::Reduce(PIdx::from(2)));
@@ -311,14 +313,14 @@ mod test {
         let st = StateTable::new(&grm, &sg);
         assert_eq!(st.actions.len(), 24);
 
-        let s0 = 0;
-        let s1 = sg.edges[s0][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s3 = sg.edges[s1][&Symbol::Terminal(grm.terminal_off("+"))];
-        let s4 = sg.edges[s1][&Symbol::Terminal(grm.terminal_off("*"))];
-        let s5 = sg.edges[s1][&Symbol::Terminal(grm.terminal_off("="))];
-        let s6 = sg.edges[s5][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s7 = sg.edges[s4][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s8 = sg.edges[s3][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s0 = StIdx(0);
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Terminal(grm.terminal_off("+"))];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Terminal(grm.terminal_off("*"))];
+        let s5 = sg.edges[usize::from(s1)][&Symbol::Terminal(grm.terminal_off("="))];
+        let s6 = sg.edges[usize::from(s5)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s7 = sg.edges[usize::from(s4)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s8 = sg.edges[usize::from(s3)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
 
         assert_eq!(st.actions[&(s6, Symbol::Terminal(grm.terminal_off("+")))], Action::Shift(s3));
         assert_eq!(st.actions[&(s6, Symbol::Terminal(grm.terminal_off("*")))], Action::Shift(s4));
@@ -355,16 +357,16 @@ mod test {
         let st = StateTable::new(&grm, &sg);
         assert_eq!(st.actions.len(), 34);
 
-        let s0 = 0;
-        let s1 = sg.edges[s0][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s3 = sg.edges[s1][&Symbol::Terminal(grm.terminal_off("+"))];
-        let s4 = sg.edges[s1][&Symbol::Terminal(grm.terminal_off("*"))];
-        let s5 = sg.edges[s1][&Symbol::Terminal(grm.terminal_off("="))];
-        let s6 = sg.edges[s1][&Symbol::Terminal(grm.terminal_off("~"))];
-        let s7 = sg.edges[s6][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s8 = sg.edges[s5][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s9 = sg.edges[s4][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
-        let s10 = sg.edges[s3][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s0 = StIdx(0);
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Terminal(grm.terminal_off("+"))];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Terminal(grm.terminal_off("*"))];
+        let s5 = sg.edges[usize::from(s1)][&Symbol::Terminal(grm.terminal_off("="))];
+        let s6 = sg.edges[usize::from(s1)][&Symbol::Terminal(grm.terminal_off("~"))];
+        let s7 = sg.edges[usize::from(s6)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s8 = sg.edges[usize::from(s5)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s9 = sg.edges[usize::from(s4)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
+        let s10 = sg.edges[usize::from(s3)][&Symbol::Nonterminal(grm.nonterminal_off("Expr"))];
 
         assert_eq!(st.actions[&(s7, Symbol::Terminal(grm.terminal_off("+")))], Action::Reduce(PIdx::from(4)));
         assert_eq!(st.actions[&(s7, Symbol::Terminal(grm.terminal_off("*")))], Action::Reduce(PIdx::from(4)));


### PR DESCRIPTION
Previously, the API that lrtable exposed had lots of public attributes, which gave people quite a bit of opportunity to unintentionally rely on details that we may wish to change in the future.

This PR is arguably a series of PRs; it's lots of commits that incrementally move us towards an API that exposes many fewer public things. The end result looks huge, so it's probably better to review one commit at a time (in reverse chronological order). There are two major types of commits: introduce a newtype for X (i.e. a newtype for usize which means that rustc won't automatically cast between X and usize); or make X private. In both cases, the "main" change is simple; dealing with the fallout in the tests then requires lots of (mostly manual) fiddling. So much of the bulk of the change is really making sure the tests still compile.

There's one naughty commit in here: 48b0d0be. This speeds up parsing by 30%, using a new part of the API. By the time I realised this shouldn't be in this PR, it's too difficult to extract it. So please forgive me for that!