### PR TITLE
Add support for %prec

### DIFF
--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -10,9 +10,15 @@ pub struct GrammarAST {
     pub precs: HashMap<String, Precedence>
 }
 
+#[derive(Debug)]
 pub struct Rule {
     pub name: String,
-    pub productions: Vec<Vec<Symbol>>
+    pub productions: Vec<Production>
+}
+
+#[derive(Debug)]
+pub struct Production {
+    pub symbols: Vec<Symbol>
 }
 
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
@@ -75,9 +81,9 @@ impl GrammarAST {
         }
     }
 
-    pub fn add_prod(&mut self, key: String, value: Vec<Symbol>) {
+    pub fn add_prod(&mut self, key: String, syms: Vec<Symbol>) {
         let rule = self.rules.entry(key.clone()).or_insert_with(|| Rule::new(key));
-        rule.add_prod(value);
+        rule.add_prod(syms);
     }
 
     pub fn get_rule(&self, key: &str) -> Option<&Rule>{
@@ -104,8 +110,8 @@ impl GrammarAST {
             }
         }
         for rule in self.rules.values() {
-            for alt in &rule.productions {
-                for sym in alt.iter() {
+            for prod in &rule.productions {
+                for sym in prod.symbols.iter() {
                     match *sym {
                         Symbol::Nonterminal(ref name) => {
                             if !self.rules.contains_key(name) {
@@ -127,16 +133,9 @@ impl GrammarAST {
     }
 }
 
-impl fmt::Debug for GrammarAST {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        let mut s = String::new();
-        s.push_str("GrammarAST:\n");
-        s.push_str(&format!("   start: {:?}\n", &self.start));
-        s.push_str(&format!("   tokens: {:?}\n", &self.tokens));
-        for rule in &self.rules {
-            s.push_str(&format!("   rule: {:?}\n", &rule));
-        }
-        writeln!(fmt, "{}", s)
+impl PartialEq for Production {
+    fn eq(&self, other: &Production) -> bool {
+        self.symbols == other.symbols
     }
 }
 
@@ -145,26 +144,8 @@ impl Rule {
         Rule {name: name, productions: vec![]}
     }
 
-    pub fn add_prod(&mut self, v: Vec<Symbol>) {
-        self.productions.push(v);
-    }
-}
-
-impl fmt::Display for Rule {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("Rule")
-           .field("name", &self.name)
-           .field("productions", &self.productions)
-           .finish()
-    }
-}
-
-impl fmt::Debug for Rule {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        fmt.debug_struct("Rule")
-           .field("name", &self.name)
-           .field("productions", &self.productions)
-           .finish()
+    pub fn add_prod(&mut self, syms: Vec<Symbol>) {
+        self.productions.push(Production{symbols: syms});
     }
 }
 

--- a/src/lib/ast.rs
+++ b/src/lib/ast.rs
@@ -75,9 +75,9 @@ impl GrammarAST {
         }
     }
 
-    pub fn add_rule(&mut self, key: String, value: Vec<Symbol>) {
+    pub fn add_prod(&mut self, key: String, value: Vec<Symbol>) {
         let rule = self.rules.entry(key.clone()).or_insert_with(|| Rule::new(key));
-        rule.add_symbols(value);
+        rule.add_prod(value);
     }
 
     pub fn get_rule(&self, key: &str) -> Option<&Rule>{
@@ -145,7 +145,7 @@ impl Rule {
         Rule {name: name, productions: vec![]}
     }
 
-    pub fn add_symbols(&mut self, v: Vec<Symbol>) {
+    pub fn add_prod(&mut self, v: Vec<Symbol>) {
         self.productions.push(v);
     }
 }
@@ -199,7 +199,7 @@ mod test {
     fn test_invalid_start_rule(){
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("B".to_string(), vec!());
+        grm.add_prod("B".to_string(), vec!());
         match grm.validate() {
             Err(GrammarValidationError{kind: GrammarValidationErrorKind::InvalidStartRule, ..}) => (),
             _ => panic!("Validation error")
@@ -210,7 +210,7 @@ mod test {
     fn test_valid_start_rule(){
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), vec!());
+        grm.add_prod("A".to_string(), vec!());
         assert!(grm.validate().is_ok());
     }
 
@@ -218,8 +218,8 @@ mod test {
     fn test_valid_nonterminal_ref(){
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), vec!(nonterminal("B")));
-        grm.add_rule("B".to_string(), vec!());
+        grm.add_prod("A".to_string(), vec!(nonterminal("B")));
+        grm.add_prod("B".to_string(), vec!());
         assert!(grm.validate().is_ok());
     }
 
@@ -227,7 +227,7 @@ mod test {
     fn test_invalid_nonterminal_ref(){
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), vec!(nonterminal("B")));
+        grm.add_prod("A".to_string(), vec!(nonterminal("B")));
         match grm.validate() {
             Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownRuleRef, ..}) => (),
             _ => panic!("Validation error")
@@ -239,7 +239,7 @@ mod test {
         let mut grm = GrammarAST::new();
         grm.tokens.insert("b".to_string());
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), vec!(terminal("b")));
+        grm.add_prod("A".to_string(), vec!(terminal("b")));
         assert!(grm.validate().is_ok());
     }
 
@@ -251,7 +251,7 @@ mod test {
         let mut grm = GrammarAST::new();
         grm.tokens.insert("b".to_string());
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), vec!(nonterminal("b")));
+        grm.add_prod("A".to_string(), vec!(nonterminal("b")));
         assert!(grm.validate().is_ok());
     }
 
@@ -259,7 +259,7 @@ mod test {
     fn test_invalid_terminal_ref(){
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), vec!(terminal("b")));
+        grm.add_prod("A".to_string(), vec!(terminal("b")));
         match grm.validate() {
             Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownToken, ..}) => (),
             _ => panic!("Validation error")
@@ -270,7 +270,7 @@ mod test {
     fn test_invalid_nonterminal_forgotten_token(){
         let mut grm = GrammarAST::new();
         grm.start = Some("A".to_string());
-        grm.add_rule("A".to_string(), vec!(nonterminal("b"), terminal("b")));
+        grm.add_prod("A".to_string(), vec!(nonterminal("b"), terminal("b")));
         match grm.validate() {
             Err(GrammarValidationError{kind: GrammarValidationErrorKind::UnknownRuleRef, ..}) => (),
             _ => panic!("Validation error")

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -158,7 +158,6 @@ impl Grammar {
             let mut rule = rules_prods.get_mut(usize::from(rule_idx)).unwrap();
             for astprod in &astrule.productions {
                 let mut prod = Vec::with_capacity(astprod.symbols.len());
-                let mut prec = None;
                 for astsym in astprod.symbols.iter() {
                     let sym = match *astsym {
                         ast::Symbol::Nonterminal(ref n) =>
@@ -168,7 +167,11 @@ impl Grammar {
                     };
                     prod.push(sym);
                 }
-                if prec.is_none() {
+                let mut prec = None;
+                if let Some(ref n) = astprod.precedence {
+                    prec = Some(*ast.precs.get(n).unwrap());
+                }
+                else {
                     for astsym in astprod.symbols.iter().rev() {
                         if let ast::Symbol::Terminal(ref n) = *astsym {
                             if let Some(p) = ast.precs.get(n) {
@@ -374,10 +377,10 @@ mod test {
                  | Expr '*' Expr
                  | Expr '~' Expr
                  | 'id' ;
-          ".to_string()).unwrap());
+          ").unwrap());
 
         assert_eq!(grm.prod_precs.len(), 8);
-        assert_eq!(grm.prod_precs[0], None); 
+        assert_eq!(grm.prod_precs[0], None);
         assert_eq!(grm.prod_precs[1].unwrap(), Precedence{level: 0, kind: AssocKind::Right});
         assert_eq!(grm.prod_precs[2].unwrap(), Precedence{level: 1, kind: AssocKind::Left});
         assert_eq!(grm.prod_precs[3].unwrap(), Precedence{level: 1, kind: AssocKind::Left});
@@ -386,4 +389,29 @@ mod test {
         assert_eq!(grm.prod_precs[6].unwrap(), Precedence{level: 4, kind: AssocKind::Nonassoc});
         assert!(grm.prod_precs[7].is_none());
     }
+
+    #[test]
+    fn test_prec_override() {
+        let grm = Grammar::new(&parse_yacc(&"
+            %start expr
+            %left '+' '-'
+            %left '*' '/'
+            %%
+            expr : expr '+' expr
+                 | expr '-' expr
+                 | expr '*' expr
+                 | expr '/' expr
+                 | '-'  expr %prec '*'
+                 | 'id' ;
+        ").unwrap());
+        assert_eq!(grm.prod_precs.len(), 7);
+        assert_eq!(grm.prod_precs[0], None);
+        assert_eq!(grm.prod_precs[1].unwrap(), Precedence{level: 0, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[2].unwrap(), Precedence{level: 0, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[3].unwrap(), Precedence{level: 1, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[4].unwrap(), Precedence{level: 1, kind: AssocKind::Left});
+        assert_eq!(grm.prod_precs[5].unwrap(), Precedence{level: 1, kind: AssocKind::Left});
+        assert!(grm.prod_precs[6].is_none());
+    }
+
 }

--- a/src/lib/grammar.rs
+++ b/src/lib/grammar.rs
@@ -157,9 +157,9 @@ impl Grammar {
             let astrule = &ast.rules[astrulename];
             let mut rule = rules_prods.get_mut(usize::from(rule_idx)).unwrap();
             for astprod in &astrule.productions {
-                let mut prod = Vec::with_capacity(astprod.len());
+                let mut prod = Vec::with_capacity(astprod.symbols.len());
                 let mut prec = None;
-                for astsym in astprod.iter() {
+                for astsym in astprod.symbols.iter() {
                     let sym = match *astsym {
                         ast::Symbol::Nonterminal(ref n) =>
                             Symbol::Nonterminal(nonterm_map[n]),
@@ -169,7 +169,7 @@ impl Grammar {
                     prod.push(sym);
                 }
                 if prec.is_none() {
-                    for astsym in astprod.iter().rev() {
+                    for astsym in astprod.symbols.iter().rev() {
                         if let ast::Symbol::Terminal(ref n) = *astsym {
                             if let Some(p) = ast.precs.get(n) {
                                 prec = Some(*p);

--- a/src/lib/yacc_parser.rs
+++ b/src/lib/yacc_parser.rs
@@ -192,13 +192,13 @@ impl YaccParser {
         i = try!(self.parse_ws(i));
         while i < self.src.len() {
             if let Some(j) = self.lookahead_is("|", i) {
-                self.grammar.add_rule(rn.clone(), syms);
+                self.grammar.add_prod(rn.clone(), syms);
                 syms = Vec::new();
                 i = try!(self.parse_ws(j));
                 continue;
             }
             else if let Some(j) = self.lookahead_is(";", i) {
-                self.grammar.add_rule(rn.clone(), syms);
+                self.grammar.add_prod(rn.clone(), syms);
                 return Ok(j);
             }
 
@@ -316,9 +316,9 @@ mod test {
         assert!(Rule::new("A".to_string()) != Rule::new("B".to_string()));
 
         let mut rule1 = Rule::new("A".to_string());
-        rule1.add_symbols(vec![terminal("a")]);
+        rule1.add_prod(vec![terminal("a")]);
         let mut rule2 = Rule::new("A".to_string());
-        rule2.add_symbols(vec![terminal("a")]);
+        rule2.add_prod(vec![terminal("a")]);
         assert_eq!(rule1, rule2);
     }
 
@@ -330,10 +330,10 @@ mod test {
         ".to_string();
         let grm = parse_yacc(&src).unwrap();
         let mut rule1 = Rule::new("A".to_string());
-        rule1.add_symbols(vec![terminal("a")]);
+        rule1.add_prod(vec![terminal("a")]);
         assert_eq!(*grm.get_rule("A").unwrap(), rule1);
         let mut rule2 = Rule::new("B".to_string());
-        rule2.add_symbols(vec![terminal("a")]);
+        rule2.add_prod(vec![terminal("a")]);
         assert!(*grm.get_rule("A").unwrap() != rule2);
     }
 
@@ -346,11 +346,11 @@ mod test {
         ".to_string();
         let grm = parse_yacc(&src).unwrap();
         let mut rule1 = Rule::new("A".to_string());
-        rule1.add_symbols(vec![terminal("a")]);
-        rule1.add_symbols(vec![terminal("b")]);
+        rule1.add_prod(vec![terminal("a")]);
+        rule1.add_prod(vec![terminal("b")]);
         assert_eq!(*grm.get_rule("A").unwrap(), rule1);
         let mut rule2 = Rule::new("B".to_string());
-        rule2.add_symbols(vec![terminal("a")]);
+        rule2.add_prod(vec![terminal("a")]);
         assert!(*grm.get_rule("A").unwrap() != rule2);
     }
 
@@ -365,17 +365,17 @@ mod test {
         let grm = parse_yacc(&src).unwrap();
 
         let mut rule1 = Rule::new("A".to_string());
-        rule1.add_symbols(vec![]);
+        rule1.add_prod(vec![]);
         assert_eq!(*grm.get_rule("A").unwrap(), rule1);
 
         let mut rule2 = Rule::new("B".to_string());
-        rule2.add_symbols(vec![terminal("b")]);
-        rule2.add_symbols(vec![]);
+        rule2.add_prod(vec![terminal("b")]);
+        rule2.add_prod(vec![]);
         assert_eq!(*grm.get_rule("B").unwrap(), rule2);
 
         let mut rule3 = Rule::new("C".to_string());
-        rule3.add_symbols(vec![]);
-        rule3.add_symbols(vec![terminal("c")]);
+        rule3.add_prod(vec![]);
+        rule3.add_prod(vec![terminal("c")]);
         assert_eq!(*grm.get_rule("C").unwrap(), rule3);
     }
 
@@ -387,11 +387,11 @@ mod test {
         ".to_string();
         let grm = parse_yacc(&src).unwrap();
         let mut rule1 = Rule::new("A".to_string());
-        rule1.add_symbols(vec![terminal("a")]);
-        rule1.add_symbols(vec![terminal("b")]);
+        rule1.add_prod(vec![terminal("a")]);
+        rule1.add_prod(vec![terminal("b")]);
         assert_eq!(*grm.get_rule("A").unwrap(), rule1);
         let mut rule2 = Rule::new("B".to_string());
-        rule2.add_symbols(vec![terminal("a")]);
+        rule2.add_prod(vec![terminal("a")]);
         assert!(*grm.get_rule("A").unwrap() != rule2);
     }
 
@@ -406,7 +406,7 @@ mod test {
         let src = "%%\nA : 'a' B;".to_string();
         let grm = parse_yacc(&src).unwrap();
         let mut rule = Rule::new("A".to_string());
-        rule.add_symbols(vec![terminal("a"), nonterminal("B")]);
+        rule.add_prod(vec![terminal("a"), nonterminal("B")]);
         assert_eq!(*grm.get_rule("A").unwrap(), rule)
     }
 
@@ -415,7 +415,7 @@ mod test {
         let src = "%%\nA : 'a' \"b\";".to_string();
         let grm = parse_yacc(&src).unwrap();
         let mut rule = Rule::new("A".to_string());
-        rule.add_symbols(vec![terminal("a"), terminal("b")]);
+        rule.add_prod(vec![terminal("a"), terminal("b")]);
         assert_eq!(*grm.get_rule("A").unwrap(), rule)
     }
 

--- a/src/lib/yacc_parser.rs
+++ b/src/lib/yacc_parser.rs
@@ -461,7 +461,7 @@ mod test {
         let src = "%token T %%\nA : T;".to_string();
         let grm = parse_yacc(&src).unwrap();
         assert!(grm.has_token("T"));
-        match grm.rules.get("A").unwrap().productions[0][0] {
+        match grm.rules.get("A").unwrap().productions[0].symbols[0] {
             Symbol::Nonterminal(_) => panic!("Should be terminal"),
             Symbol::Terminal(_)    => ()
         }


### PR DESCRIPTION
This allows Yacc grammars like the following to be accepted and, hopefully, work correctly:

```
            %start expr
            %left '+' '-'
            %left '*' '/'
            %%
            expr : expr '+' expr
                 | expr '-' expr
                 | expr '*' expr
                 | expr '/' expr
                 | %prec '-'  expr '*'
                 | 'id' ;
```