### PR TITLE
This docstring was broken.

### DIFF
--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -61,14 +61,14 @@ use grammar::{PIdx, Grammar, NTIdx, Symbol, SIdx, TIdx};
 /// The type of "context" (also known as "lookaheads")
 pub type Ctx = BitVec;
 
-// Firsts stores all the first sets for a given grammar:
+// Firsts stores all the first sets for a given grammar. For example, given this code and grammar:
 //   let grm = Grammar::new(parse_yacc("
 //     S: A 'b';
 //     A: 'a'
 //      | ;"));
 //   let firsts = Firsts::new(&grm);
-//   // Given the above grammar then the following assertions (and only the following assertions)
-//   // about the firsts set are correct:
+// then the following assertions (and only the following assertions) about the firsts set are
+// correct:
 //   assert!(firsts.is_set(grm.nonterminal_off("S"), grm.terminal_off("a")));
 //   assert!(firsts.is_set(grm.nonterminal_off("S"), grm.terminal_off("b")));
 //   assert!(firsts.is_set(grm.nonterminal_off("A"), grm.terminal_off("a")));

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -61,30 +61,18 @@ use grammar::{PIdx, Grammar, NTIdx, Symbol, SIdx, TIdx};
 /// The type of "context" (also known as "lookaheads")
 pub type Ctx = BitVec;
 
-/// Firsts stores all the first sets for a given grammar.
-///
-/// # Example
-/// Given a grammar `input`:
-///
-/// ```c
-/// S : A "b";
-/// A : "a" |;
-/// ```
-///
-/// ```c
-/// let grm = Grammar::new(parse_yacc(&input));
-/// let firsts = Firsts::new(grm);
-/// ```
-///
-/// Then the following assertions (and only the following assertions) about the firsts set are
-/// correct:
-/// ```c
-/// assert!(firsts.is_set(grm.nonterminal_off("S"), grm.terminal_off("a")));
-/// assert!(firsts.is_set(grm.nonterminal_off("S"), grm.terminal_off("b")));
-/// assert!(firsts.is_epsilon_set(grm.nonterminal_off("S")));
-/// assert!(firsts.is_set(grm.nonterminal_off("A"), grm.terminal_off("a")));
-/// assert!(firsts.is_epsilon_set(grm.nonterminal_off("A")));
-/// ```
+// Firsts stores all the first sets for a given grammar:
+//   let grm = Grammar::new(parse_yacc("
+//     S: A 'b';
+//     A: 'a'
+//      | ;"));
+//   let firsts = Firsts::new(&grm);
+//   // Given the above grammar then the following assertions (and only the following assertions)
+//   // about the firsts set are correct:
+//   assert!(firsts.is_set(grm.nonterminal_off("S"), grm.terminal_off("a")));
+//   assert!(firsts.is_set(grm.nonterminal_off("S"), grm.terminal_off("b")));
+//   assert!(firsts.is_set(grm.nonterminal_off("A"), grm.terminal_off("a")));
+//   assert!(firsts.is_epsilon_set(grm.nonterminal_off("A")));
 #[derive(Debug)]
 struct Firsts {
     // The representation is a contiguous bitfield, of (terms_len * 1) * nonterms_len. Put another


### PR DESCRIPTION
First, it wasn't actually executing as a doc test. Second, it had an incorrect assertion:

```
  assert!(firsts.is_epsilon_set(grm.nonterminal_off("S")));
```

However, since Firsts is private to stategraph.rs, testing it as a doc test is impossible (there's no way to "use" Firsts). So there's no point pretending this comment is anything other than a bog-standard comment. So turn the doc test into a comment and fix the assertion.