### PR TITLE
Remove explicit EOF term

### DIFF
--- a/src/lib/firsts.rs
+++ b/src/lib/firsts.rs
@@ -55,15 +55,10 @@ use cfgrammar::yacc::YaccGrammar;
 /// ```
 #[derive(Debug)]
 pub struct Firsts {
-    // The representation is a contiguous bitfield, of (terms_len * 1) * nonterms_len. Put another
-    // way, each nonterminal has (terms_len + 1) bits, where the bit at position terms_len
-    // represents epsilon. So for the grammar given above, the bitvector would be two sequences of
-    // 3 bits where bits 0, 1, 2 represent terminals a, b, epsilon respectively.
-    //   111101
-    // Where "111" is for the nonterminal S, and 101 for A.
+    // Each production has grm.terms_len() + 1 bits: the bit at position grm.terms_len represents
+    // the EOF terminal.
     prod_firsts: Vec<BitVec>,
-    prod_epsilons: BitVec,
-    terms_len: usize
+    prod_epsilons: BitVec
 }
 
 impl Firsts {
@@ -71,12 +66,11 @@ impl Firsts {
     pub fn new(grm: &YaccGrammar) -> Firsts {
         let mut prod_firsts = Vec::with_capacity(grm.nonterms_len());
         for _ in 0..grm.nonterms_len() {
-            prod_firsts.push(BitVec::from_elem(grm.terms_len(), false));
+            prod_firsts.push(BitVec::from_elem(grm.terms_len() + 1, false));
         }
         let mut firsts = Firsts {
             prod_firsts  : prod_firsts,
             prod_epsilons: BitVec::from_elem(grm.nonterms_len(), false),
-            terms_len   : grm.terms_len()
         };
 
         // Loop looking for changes to the firsts set, until we reach a fixed point. In essence, we
@@ -141,7 +135,9 @@ impl Firsts {
                     }
                 }
             }
-            if !changed { return firsts; }
+            if !changed {
+                return firsts;
+            }
         }
     }
 

--- a/src/lib/firsts.rs
+++ b/src/lib/firsts.rs
@@ -106,9 +106,9 @@ impl Firsts {
                                 // together with the current nonterminals FIRSTs. Note this is
                                 // (intentionally) a no-op if the two terminals are one and the
                                 // same.
-                                for term_idx in grm.iter_term_idxs() {
-                                    if firsts.is_set(nonterm_i, term_idx)
-                                      && !firsts.set(rul_i, term_idx) {
+                                for term_idx in 0..grm.terms_len() {
+                                    if firsts.is_set(nonterm_i, TIdx::from(term_idx))
+                                      && !firsts.set(rul_i, TIdx::from(term_idx)) {
                                         changed = true;
                                     }
                                 }

--- a/src/lib/firsts.rs
+++ b/src/lib/firsts.rs
@@ -42,16 +42,16 @@ use cfgrammar::yacc::YaccGrammar;
 ///   let grm = yacc_grm(YaccKind::Original, "
 ///     S: A 'b';
 ///     A: 'a'
-///      | ;");
+///      | ;").unwrap();
 ///   let firsts = Firsts::new(&grm);
 /// ```
 /// then the following assertions (and only the following assertions) about the firsts set are
 /// correct:
 /// ```
-///   assert!(firsts.is_set(grm.nonterminal_off("S"), grm.terminal_off("a")));
-///   assert!(firsts.is_set(grm.nonterminal_off("S"), grm.terminal_off("b")));
-///   assert!(firsts.is_set(grm.nonterminal_off("A"), grm.terminal_off("a")));
-///   assert!(firsts.is_epsilon_set(grm.nonterminal_off("A")));
+///   assert!(firsts.is_set(grm.nonterm_off("S"), grm.term_off("a")));
+///   assert!(firsts.is_set(grm.nonterm_off("S"), grm.term_off("b")));
+///   assert!(firsts.is_set(grm.nonterm_off("A"), grm.term_off("a")));
+///   assert!(firsts.is_epsilon_set(grm.nonterm_off("A")));
 /// ```
 #[derive(Debug)]
 pub struct Firsts {
@@ -178,7 +178,7 @@ mod test {
     use cfgrammar::yacc::{yacc_grm, YaccGrammar, YaccKind};
 
     fn has(grm: &YaccGrammar, firsts: &Firsts, rn: &str, should_be: Vec<&str>) {
-        let nt_i = grm.nonterminal_off(rn);
+        let nt_i = grm.nonterm_off(rn);
         for i in 0 .. grm.terms_len() {
             let n = grm.term_name(i.into()).unwrap();
             match should_be.iter().position(|&x| x == n) {

--- a/src/lib/itemset.rs
+++ b/src/lib/itemset.rs
@@ -98,7 +98,7 @@ impl Itemset {
         let mut keys_iter = self.items.keys(); // The initial todo list
         type BitVecBitSize = u32; // As of 0.4.3, BitVec only supports u32 blocks
         let mut zero_todos = BitVec::<BitVecBitSize>::from_elem(grm.prods_len(), false); // Subsequent todos
-        let mut new_ctx = BitVec::from_elem(grm.terms_len(), false);
+        let mut new_ctx = BitVec::from_elem(grm.terms_len() + 1, false);
         loop {
             let prod_i;
             let dot;
@@ -205,8 +205,8 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = BitVec::from_elem(grm.terms_len(), false);
-        la.set(usize::from(grm.terminal_off("$")), true);
+        let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
+        la.set(grm.terms_len(), true);
         is.add(grm.nonterm_to_prods(grm.nonterminal_off("^")).unwrap()[0], 0.into(), &la);
         let cls_is = is.close(&grm, &firsts);
         println!("{:?}", cls_is);
@@ -239,8 +239,8 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = BitVec::from_elem(grm.terms_len(), false);
-        la.set(usize::from(grm.terminal_off("$")), true);
+        let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
+        la.set(grm.terms_len(), true);
         is.add(grm.nonterm_to_prods(grm.nonterminal_off("^")).unwrap()[0], 0.into(), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
@@ -281,8 +281,8 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = BitVec::from_elem(grm.terms_len(), false);
-        la.set(usize::from(grm.terminal_off("$")), true);
+        let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
+        la.set(grm.terms_len(), true);
         is.add(grm.nonterm_to_prods(grm.nonterminal_off("^")).unwrap()[0], 0.into(), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
@@ -291,9 +291,9 @@ mod test {
         state_exists(&grm, &cls_is, "S", 1, 0, vec!["b", "$"]);
 
         is = Itemset::new(&grm);
-        la = BitVec::from_elem(grm.terms_len(), false);
+        la = BitVec::from_elem(grm.terms_len() + 1, false);
         la.set(usize::from(grm.terminal_off("b")), true);
-        la.set(usize::from(grm.terminal_off("$")), true);
+        la.set(grm.terms_len(), true);
         is.add(grm.nonterm_to_prods(grm.nonterminal_off("S")).unwrap()[1], 1.into(), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "A", 0, 0, vec!["a"]);
@@ -301,7 +301,7 @@ mod test {
         state_exists(&grm, &cls_is, "A", 2, 0, vec!["a"]);
 
         is = Itemset::new(&grm);
-        la = BitVec::from_elem(grm.terms_len(), false);
+        la = BitVec::from_elem(grm.terms_len() + 1, false);
         la.set(usize::from(grm.terminal_off("a")), true);
         is.add(grm.nonterm_to_prods(grm.nonterminal_off("A")).unwrap()[0], 1.into(), &la);
         cls_is = is.close(&grm, &firsts);
@@ -315,8 +315,8 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = BitVec::from_elem(grm.terms_len(), false);
-        la.set(usize::from(grm.terminal_off("$")), true);
+        let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
+        la.set(grm.terms_len(), true);
         is.add(grm.nonterm_to_prods(grm.nonterminal_off("^")).unwrap()[0], 0.into(), &la);
         let cls_is = is.close(&grm, &firsts);
 

--- a/src/lib/itemset.rs
+++ b/src/lib/itemset.rs
@@ -207,7 +207,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
         la.set(grm.terms_len(), true);
-        is.add(grm.nonterm_to_prods(grm.nonterminal_off("^")).unwrap()[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
         let cls_is = is.close(&grm, &firsts);
         println!("{:?}", cls_is);
         assert_eq!(cls_is.items.len(), 6);
@@ -241,7 +241,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
         la.set(grm.terms_len(), true);
-        is.add(grm.nonterm_to_prods(grm.nonterminal_off("^")).unwrap()[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
         state_exists(&grm, &cls_is, "^", 0, 0, vec!["$"]);
@@ -250,7 +250,7 @@ mod test {
         state_exists(&grm, &cls_is, "S", 2, 0, vec!["b", "$"]);
 
         is = Itemset::new(&grm);
-        is.add(grm.nonterm_to_prods(grm.nonterminal_off("F")).unwrap()[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_off("F")).unwrap()[0], 0.into(), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "F", 0, 0, vec!["$"]);
         state_exists(&grm, &cls_is, "C", 0, 0, vec!["d", "f"]);
@@ -283,7 +283,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
         la.set(grm.terms_len(), true);
-        is.add(grm.nonterm_to_prods(grm.nonterminal_off("^")).unwrap()[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
         state_exists(&grm, &cls_is, "^", 0, 0, vec!["$"]);
@@ -292,9 +292,9 @@ mod test {
 
         is = Itemset::new(&grm);
         la = BitVec::from_elem(grm.terms_len() + 1, false);
-        la.set(usize::from(grm.terminal_off("b")), true);
+        la.set(usize::from(grm.term_off("b")), true);
         la.set(grm.terms_len(), true);
-        is.add(grm.nonterm_to_prods(grm.nonterminal_off("S")).unwrap()[1], 1.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_off("S")).unwrap()[1], 1.into(), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "A", 0, 0, vec!["a"]);
         state_exists(&grm, &cls_is, "A", 1, 0, vec!["a"]);
@@ -302,8 +302,8 @@ mod test {
 
         is = Itemset::new(&grm);
         la = BitVec::from_elem(grm.terms_len() + 1, false);
-        la.set(usize::from(grm.terminal_off("a")), true);
-        is.add(grm.nonterm_to_prods(grm.nonterminal_off("A")).unwrap()[0], 1.into(), &la);
+        la.set(usize::from(grm.term_off("a")), true);
+        is.add(grm.nonterm_to_prods(grm.nonterm_off("A")).unwrap()[0], 1.into(), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "S", 0, 0, vec!["b", "c"]);
         state_exists(&grm, &cls_is, "S", 1, 0, vec!["b", "c"]);
@@ -317,19 +317,19 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
         la.set(grm.terms_len(), true);
-        is.add(grm.nonterm_to_prods(grm.nonterminal_off("^")).unwrap()[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
         let cls_is = is.close(&grm, &firsts);
 
-        let goto1 = cls_is.goto(&grm, &Symbol::Nonterm(grm.nonterminal_off("S")));
+        let goto1 = cls_is.goto(&grm, &Symbol::Nonterm(grm.nonterm_off("S")));
         state_exists(&grm, &goto1, "^", 0, 1, vec!["$"]);
         state_exists(&grm, &goto1, "S", 0, 1, vec!["$", "b"]);
 
         // follow 'b' from start set
-        let goto2 = cls_is.goto(&grm, &Symbol::Term(grm.terminal_off("b")));
+        let goto2 = cls_is.goto(&grm, &Symbol::Term(grm.term_off("b")));
         state_exists(&grm, &goto2, "S", 1, 1, vec!["$", "b"]);
 
         // continue by following 'a' from last goto, after it's been closed
-        let goto3 = goto2.close(&grm, &firsts).goto(&grm, &Symbol::Term(grm.terminal_off("a")));
+        let goto3 = goto2.close(&grm, &firsts).goto(&grm, &Symbol::Term(grm.term_off("a")));
         state_exists(&grm, &goto3, "A", 1, 1, vec!["a"]);
         state_exists(&grm, &goto3, "A", 2, 1, vec!["a"]);
     }

--- a/src/lib/pager.rs
+++ b/src/lib/pager.rs
@@ -429,33 +429,33 @@ mod test {
         state_exists(&grm, &sg.states[0], "S", 0, 0, vec!["$", "b"]);
         state_exists(&grm, &sg.states[0], "S", 1, 0, vec!["$", "b"]);
 
-        let s1 = sg.edges[0][&Symbol::Nonterm(grm.nonterminal_off("S"))];
+        let s1 = sg.edges[0][&Symbol::Nonterm(grm.nonterm_off("S"))];
         assert_eq!(sg.states[usize::from(s1)].items.len(), 2);
         state_exists(&grm, &sg.states[usize::from(s1)], "^", 0, 1, vec!["$"]);
         state_exists(&grm, &sg.states[usize::from(s1)], "S", 0, 1, vec!["$", "b"]);
 
-        let s2 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("b"))];
+        let s2 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("b"))];
         assert_eq!(sg.states[usize::from(s2)].items.len(), 1);
         state_exists(&grm, &sg.states[usize::from(s2)], "S", 0, 2, vec!["$", "b"]);
 
-        let s3 = sg.edges[0][&Symbol::Term(grm.terminal_off("b"))];
+        let s3 = sg.edges[0][&Symbol::Term(grm.term_off("b"))];
         assert_eq!(sg.states[usize::from(s3)].items.len(), 4);
         state_exists(&grm, &sg.states[usize::from(s3)], "S", 1, 1, vec!["$", "b", "c"]);
         state_exists(&grm, &sg.states[usize::from(s3)], "A", 0, 0, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s3)], "A", 1, 0, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s3)], "A", 2, 0, vec!["a"]);
 
-        let s4 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterminal_off("A"))];
+        let s4 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("A"))];
         assert_eq!(sg.states[usize::from(s4)].items.len(), 1);
         state_exists(&grm, &sg.states[usize::from(s4)], "S", 1, 2, vec!["$", "b", "c"]);
 
-        let s5 = sg.edges[usize::from(s4)][&Symbol::Term(grm.terminal_off("a"))];
+        let s5 = sg.edges[usize::from(s4)][&Symbol::Term(grm.term_off("a"))];
         assert_eq!(sg.states[usize::from(s5)].items.len(), 1);
         state_exists(&grm, &sg.states[usize::from(s5)], "S", 1, 3, vec!["$", "b", "c"]);
 
-        let s6 = sg.edges[usize::from(s3)][&Symbol::Term(grm.terminal_off("a"))];
+        let s6 = sg.edges[usize::from(s3)][&Symbol::Term(grm.term_off("a"))];
         // result from merging 10 into 3
-        assert_eq!(s3, sg.edges[usize::from(s6)][&Symbol::Term(grm.terminal_off("b"))]);
+        assert_eq!(s3, sg.edges[usize::from(s6)][&Symbol::Term(grm.term_off("b"))]);
         assert_eq!(sg.states[usize::from(s6)].items.len(), 5);
         state_exists(&grm, &sg.states[usize::from(s6)], "A", 0, 1, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s6)], "A", 1, 1, vec!["a"]);
@@ -463,17 +463,17 @@ mod test {
         state_exists(&grm, &sg.states[usize::from(s6)], "S", 0, 0, vec!["b", "c"]);
         state_exists(&grm, &sg.states[usize::from(s6)], "S", 1, 0, vec!["b", "c"]);
 
-        let s7 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterminal_off("S"))];
+        let s7 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterm_off("S"))];
         assert_eq!(sg.states[usize::from(s7)].items.len(), 3);
         state_exists(&grm, &sg.states[usize::from(s7)], "A", 0, 2, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s7)], "A", 2, 2, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s7)], "S", 0, 1, vec!["b", "c"]);
 
-        let s8 = sg.edges[usize::from(s7)][&Symbol::Term(grm.terminal_off("c"))];
+        let s8 = sg.edges[usize::from(s7)][&Symbol::Term(grm.term_off("c"))];
         assert_eq!(sg.states[usize::from(s8)].items.len(), 1);
         state_exists(&grm, &sg.states[usize::from(s8)], "A", 0, 3, vec!["a"]);
 
-        let s9 = sg.edges[usize::from(s7)][&Symbol::Term(grm.terminal_off("b"))];
+        let s9 = sg.edges[usize::from(s7)][&Symbol::Term(grm.term_off("b"))];
         assert_eq!(sg.states[usize::from(s9)].items.len(), 2);
         state_exists(&grm, &sg.states[usize::from(s9)], "A", 2, 3, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s9)], "S", 0, 2, vec!["b", "c"]);
@@ -509,7 +509,7 @@ mod test {
         state_exists(&grm, &sg.states[0], "X", 4, 0, vec!["$"]);
         state_exists(&grm, &sg.states[0], "X", 5, 0, vec!["$"]);
 
-        let s1 = sg.edges[0][&Symbol::Term(grm.terminal_off("a"))];
+        let s1 = sg.edges[0][&Symbol::Term(grm.term_off("a"))];
         assert_eq!(sg.states[usize::from(s1)].items.len(), 7);
         state_exists(&grm, &sg.states[usize::from(s1)], "X", 0, 1, vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.states[usize::from(s1)], "X", 1, 1, vec!["a", "d", "e", "$"]);
@@ -519,7 +519,7 @@ mod test {
         state_exists(&grm, &sg.states[usize::from(s1)], "Z", 0, 0, vec!["c"]);
         state_exists(&grm, &sg.states[usize::from(s1)], "T", 0, 0, vec!["a", "d", "e", "$"]);
 
-        let s7 = sg.edges[0][&Symbol::Term(grm.terminal_off("b"))];
+        let s7 = sg.edges[0][&Symbol::Term(grm.term_off("b"))];
         assert_eq!(sg.states[usize::from(s7)].items.len(), 7);
         state_exists(&grm, &sg.states[usize::from(s7)], "X", 3, 1, vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.states[usize::from(s7)], "X", 4, 1, vec!["a", "d", "e", "$"]);
@@ -529,9 +529,9 @@ mod test {
         state_exists(&grm, &sg.states[usize::from(s1)], "Z", 0, 0, vec!["c"]);
         state_exists(&grm, &sg.states[usize::from(s1)], "T", 0, 0, vec!["a", "d", "e", "$"]);
 
-        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("u"))];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("u"))];
         assert_eq!(sg.states[usize::from(s4)].items.len(), 8);
-        assert_eq!(s4, sg.edges[usize::from(s7)][&Symbol::Term(grm.terminal_off("u"))]);
+        assert_eq!(s4, sg.edges[usize::from(s7)][&Symbol::Term(grm.term_off("u"))]);
         state_exists(&grm, &sg.states[usize::from(s4)], "Y", 1, 1, vec!["d", "e"]);
         state_exists(&grm, &sg.states[usize::from(s4)], "T", 0, 1, vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.states[usize::from(s4)], "X", 0, 0, vec!["a", "d", "e"]);
@@ -541,37 +541,37 @@ mod test {
         state_exists(&grm, &sg.states[usize::from(s4)], "X", 4, 0, vec!["a", "d", "e"]);
         state_exists(&grm, &sg.states[usize::from(s4)], "X", 5, 0, vec!["a", "d", "e"]);
 
-        assert_eq!(s1, sg.edges[usize::from(s4)][&Symbol::Term(grm.terminal_off("a"))]);
-        assert_eq!(s7, sg.edges[usize::from(s4)][&Symbol::Term(grm.terminal_off("b"))]);
+        assert_eq!(s1, sg.edges[usize::from(s4)][&Symbol::Term(grm.term_off("a"))]);
+        assert_eq!(s7, sg.edges[usize::from(s4)][&Symbol::Term(grm.term_off("b"))]);
 
-        let s2 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("t"))];
+        let s2 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("t"))];
         assert_eq!(sg.states[usize::from(s2)].items.len(), 3);
         state_exists(&grm, &sg.states[usize::from(s2)], "Y", 0, 1, vec!["d"]);
         state_exists(&grm, &sg.states[usize::from(s2)], "Z", 0, 1, vec!["c"]);
         state_exists(&grm, &sg.states[usize::from(s2)], "W", 0, 0, vec!["d"]);
 
-        let s3 = sg.edges[usize::from(s2)][&Symbol::Term(grm.terminal_off("u"))];
+        let s3 = sg.edges[usize::from(s2)][&Symbol::Term(grm.term_off("u"))];
         assert_eq!(sg.states[usize::from(s3)].items.len(), 3);
         state_exists(&grm, &sg.states[usize::from(s3)], "Z", 0, 2, vec!["c"]);
         state_exists(&grm, &sg.states[usize::from(s3)], "W", 0, 1, vec!["d"]);
         state_exists(&grm, &sg.states[usize::from(s3)], "V", 0, 0, vec!["d"]);
 
-        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterminal_off("X"))];
+        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_off("X"))];
         assert_eq!(sg.states[usize::from(s5)].items.len(), 2);
         state_exists(&grm, &sg.states[usize::from(s5)], "Y", 1, 2, vec!["d", "e"]);
         state_exists(&grm, &sg.states[usize::from(s5)], "T", 0, 2, vec!["a", "d", "e", "$"]);
 
-        let s6 = sg.edges[usize::from(s5)][&Symbol::Term(grm.terminal_off("a"))];
+        let s6 = sg.edges[usize::from(s5)][&Symbol::Term(grm.term_off("a"))];
         assert_eq!(sg.states[usize::from(s6)].items.len(), 1);
         state_exists(&grm, &sg.states[usize::from(s6)], "T", 0, 3, vec!["a", "d", "e", "$"]);
 
-        let s8 = sg.edges[usize::from(s7)][&Symbol::Term(grm.terminal_off("t"))];
+        let s8 = sg.edges[usize::from(s7)][&Symbol::Term(grm.term_off("t"))];
         assert_eq!(sg.states[usize::from(s8)].items.len(), 3);
         state_exists(&grm, &sg.states[usize::from(s8)], "Y", 0, 1, vec!["e"]);
         state_exists(&grm, &sg.states[usize::from(s8)], "Z", 0, 1, vec!["d"]);
         state_exists(&grm, &sg.states[usize::from(s8)], "W", 0, 0, vec!["e"]);
 
-        let s9 = sg.edges[usize::from(s8)][&Symbol::Term(grm.terminal_off("u"))];
+        let s9 = sg.edges[usize::from(s8)][&Symbol::Term(grm.term_off("u"))];
         assert_eq!(sg.states[usize::from(s9)].items.len(), 3);
         state_exists(&grm, &sg.states[usize::from(s9)], "Z", 0, 2, vec!["d"]);
         state_exists(&grm, &sg.states[usize::from(s9)], "W", 0, 1, vec!["e"]);
@@ -580,49 +580,49 @@ mod test {
         // Ommitted successors from the graph in Fig.3
 
         // X-successor of S0
-        let s0x = sg.edges[0][&Symbol::Nonterm(grm.nonterminal_off("X"))];
+        let s0x = sg.edges[0][&Symbol::Nonterm(grm.nonterm_off("X"))];
         state_exists(&grm, &sg.states[usize::from(s0x)], "^", 0, 1, vec!["$"]);
 
         // Y-successor of S1 (and it's d-successor)
-        let s1y = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterminal_off("Y"))];
+        let s1y = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterm_off("Y"))];
         state_exists(&grm, &sg.states[usize::from(s1y)], "X", 0, 2, vec!["a", "d", "e", "$"]);
-        let s1yd = sg.edges[usize::from(s1y)][&Symbol::Term(grm.terminal_off("d"))];
+        let s1yd = sg.edges[usize::from(s1y)][&Symbol::Term(grm.term_off("d"))];
         state_exists(&grm, &sg.states[usize::from(s1yd)], "X", 0, 3, vec!["a", "d", "e", "$"]);
 
         // Z-successor of S1 (and it's successor)
-        let s1z = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterminal_off("Z"))];
+        let s1z = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterm_off("Z"))];
         state_exists(&grm, &sg.states[usize::from(s1z)], "X", 1, 2, vec!["a", "d", "e", "$"]);
-        let s1zc = sg.edges[usize::from(s1z)][&Symbol::Term(grm.terminal_off("c"))];
+        let s1zc = sg.edges[usize::from(s1z)][&Symbol::Term(grm.term_off("c"))];
         state_exists(&grm, &sg.states[usize::from(s1zc)], "X", 1, 3, vec!["a", "d", "e", "$"]);
 
         // T-successor of S1
-        let s1t = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterminal_off("T"))];
+        let s1t = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterm_off("T"))];
         state_exists(&grm, &sg.states[usize::from(s1t)], "X", 2, 2, vec!["a", "d", "e", "$"]);
 
         // Y-successor of S7 (and it's d-successor)
-        let s7y = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterminal_off("Y"))];
+        let s7y = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterm_off("Y"))];
         state_exists(&grm, &sg.states[usize::from(s7y)], "X", 3, 2, vec!["a", "d", "e", "$"]);
-        let s7ye = sg.edges[usize::from(s7y)][&Symbol::Term(grm.terminal_off("e"))];
+        let s7ye = sg.edges[usize::from(s7y)][&Symbol::Term(grm.term_off("e"))];
         state_exists(&grm, &sg.states[usize::from(s7ye)], "X", 3, 3, vec!["a", "d", "e", "$"]);
 
         // Z-successor of S7 (and it's successor)
-        let s7z = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterminal_off("Z"))];
+        let s7z = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterm_off("Z"))];
         state_exists(&grm, &sg.states[usize::from(s7z)], "X", 4, 2, vec!["a", "d", "e", "$"]);
-        let s7zd = sg.edges[usize::from(s7z)][&Symbol::Term(grm.terminal_off("d"))];
+        let s7zd = sg.edges[usize::from(s7z)][&Symbol::Term(grm.term_off("d"))];
         state_exists(&grm, &sg.states[usize::from(s7zd)], "X", 4, 3, vec!["a", "d", "e", "$"]);
 
         // T-successor of S7
-        let s7t = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterminal_off("T"))];
+        let s7t = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterm_off("T"))];
         state_exists(&grm, &sg.states[usize::from(s7t)], "X", 5, 2, vec!["a", "d", "e", "$"]);
 
         // W-successor of S2 and S8 (merged)
-        let s8w = sg.edges[usize::from(s8)][&Symbol::Nonterm(grm.nonterminal_off("W"))];
-        assert_eq!(s8w, sg.edges[usize::from(s2)][&Symbol::Nonterm(grm.nonterminal_off("W"))]);
+        let s8w = sg.edges[usize::from(s8)][&Symbol::Nonterm(grm.nonterm_off("W"))];
+        assert_eq!(s8w, sg.edges[usize::from(s2)][&Symbol::Nonterm(grm.nonterm_off("W"))]);
         state_exists(&grm, &sg.states[usize::from(s8w)], "Y", 0, 2, vec!["d", "e"]);
 
         // V-successor of S3 and S9 (merged)
-        let s9v = sg.edges[usize::from(s9)][&Symbol::Nonterm(grm.nonterminal_off("V"))];
-        assert_eq!(s9v, sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterminal_off("V"))]);
+        let s9v = sg.edges[usize::from(s9)][&Symbol::Nonterm(grm.nonterm_off("V"))];
+        assert_eq!(s9v, sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("V"))]);
         state_exists(&grm, &sg.states[usize::from(s9v)], "W", 0, 2, vec!["d", "e"]);
     }
 

--- a/src/lib/pager.rs
+++ b/src/lib/pager.rs
@@ -156,8 +156,8 @@ pub fn pager_stategraph(grm: &YaccGrammar) -> StateGraph {
     let mut edges: Vec<HashMap<Symbol, StIdx>> = Vec::new();
 
     let mut state0 = Itemset::new(grm);
-    let mut ctx = BitVec::from_elem(grm.terms_len(), false);
-    ctx.set(grm.eof_term_idx().into(), true);
+    let mut ctx = BitVec::from_elem(grm.terms_len() + 1, false);
+    ctx.set(grm.terms_len(), true);
     state0.add(grm.start_prod(), SIdx::from(0), &ctx);
     closed_states.push(None);
     core_states.push(state0);
@@ -166,14 +166,14 @@ pub fn pager_stategraph(grm: &YaccGrammar) -> StateGraph {
     // We maintain two lists of which nonterms and terms we've seen; when processing a given
     // state there's no point processing a nonterm or term more than once.
     let mut seen_nonterms = BitVec::from_elem(grm.nonterms_len(), false);
-    let mut seen_terms = BitVec::from_elem(grm.terms_len(), false);
+    let mut seen_terms = BitVec::from_elem(grm.terms_len() + 1, false);
     // new_states is used to separate out iterating over states vs. mutating it
     let mut new_states = Vec::new();
     // cnd_[nonterm|term]_weaklies represent which states are possible weakly compatible
     // matches for a given symbol.
     let mut cnd_nonterm_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(grm.nonterms_len());
-    let mut cnd_term_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(grm.terms_len());
-    for _ in 0..grm.terms_len() { cnd_term_weaklies.push(Vec::new()); }
+    let mut cnd_term_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(grm.terms_len() + 1);
+    for _ in 0..grm.terms_len() + 1 { cnd_term_weaklies.push(Vec::new()); }
     for _ in 0..grm.nonterms_len() { cnd_nonterm_weaklies.push(Vec::new()); }
 
     let mut todo = 1; // How many None values are there in closed_states?

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -52,7 +52,7 @@ use cfgrammar::yacc::YaccGrammar;
 pub fn state_exists(grm: &YaccGrammar, is: &Itemset, nt: &str, prod_off: usize, dot: usize, la:
                     Vec<&str>) {
 
-    let ab_prod_off = grm.nonterm_to_prods(grm.nonterminal_off(nt)).unwrap()[prod_off];
+    let ab_prod_off = grm.nonterm_to_prods(grm.nonterm_off(nt)).unwrap()[prod_off];
     let ctx = &is.items[&(ab_prod_off, dot.into())];
     for i in 0..grm.terms_len() + 1 {
         let bit = ctx[i];
@@ -61,7 +61,7 @@ pub fn state_exists(grm: &YaccGrammar, is: &Itemset, nt: &str, prod_off: usize, 
             let off = if t == &"$" {
                     TIdx::from(grm.terms_len())
                 } else {
-                    grm.terminal_off(t)
+                    grm.term_off(t)
                 };
             if off == i.into() {
                 if !bit {

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -44,7 +44,7 @@ pub struct StateGraph {
 }
 
 #[cfg(test)]
-use cfgrammar::Grammar;
+use cfgrammar::{Grammar, TIdx};
 #[cfg(test)]
 use cfgrammar::yacc::YaccGrammar;
 
@@ -54,11 +54,16 @@ pub fn state_exists(grm: &YaccGrammar, is: &Itemset, nt: &str, prod_off: usize, 
 
     let ab_prod_off = grm.nonterm_to_prods(grm.nonterminal_off(nt)).unwrap()[prod_off];
     let ctx = &is.items[&(ab_prod_off, dot.into())];
-    for i in 0..grm.terms_len() {
+    for i in 0..grm.terms_len() + 1 {
         let bit = ctx[i];
         let mut found = false;
         for t in la.iter() {
-            if grm.terminal_off(t) == i.into() {
+            let off = if t == &"$" {
+                    TIdx::from(grm.terms_len())
+                } else {
+                    grm.terminal_off(t)
+                };
+            if off == i.into() {
                 if !bit {
                     panic!("bit for terminal {}, dot {} is not set in production {} of {} when it should be",
                            t, dot, prod_off, nt);

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -34,7 +34,7 @@ use std::collections::hash_map::{Entry, HashMap, OccupiedEntry};
 use std::fmt;
 
 use StIdx;
-use cfgrammar::{PIdx, NTIdx, Symbol, TIdx};
+use cfgrammar::{Grammar, PIdx, NTIdx, Symbol, TIdx};
 use cfgrammar::yacc::{AssocKind, YaccGrammar};
 use stategraph::StateGraph;
 
@@ -63,6 +63,8 @@ impl fmt::Display for StateTableError {
 
 /// A representation of a `StateTable` for a grammar. `actions` and `gotos` are split into two
 /// separate hashmaps, rather than a single table, due to the different types of their values.
+/// Note that since cfgrammar does not explicitly represent the EOF terminal, we use
+/// `Symbol::Term(TIdx::from(grm.terms_len()))` to represent it in the actions.
 #[derive(Debug)]
 pub struct StateTable {
     actions          : HashMap<(StIdx, Symbol), Action>,
@@ -119,7 +121,7 @@ impl StateTable {
                             }
                         }
                         Entry::Vacant(e) => {
-                            if prod_i == grm.start_prod() && TIdx::from(term_i) == grm.eof_term_idx() {
+                            if prod_i == grm.start_prod() && term_i == grm.terms_len() {
                                 e.insert(Action::Accept);
                             }
                             else {
@@ -223,7 +225,7 @@ fn resolve_shift_reduce(grm: &YaccGrammar, mut e: OccupiedEntry<(StIdx, Symbol),
 mod test {
     use StIdx;
     use super::{Action, StateTable, StateTableError, StateTableErrorKind};
-    use cfgrammar::{Symbol, TIdx};
+    use cfgrammar::{Grammar, Symbol, TIdx};
     use cfgrammar::yacc::{yacc_grm, YaccKind};
     use pager::pager_stategraph;
 
@@ -260,20 +262,20 @@ mod test {
         };
 
         assert_eq!(st.action(s0, Symbol::Term(grm.terminal_off("id"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s1, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Accept);
+        assert_eq!(st.action(s1, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Accept);
         assert_eq!(st.action(s2, Symbol::Term(grm.terminal_off("-"))).unwrap(), Action::Shift(s5));
-        assert_reduce(s2, grm.eof_term_idx(), "Expr", 1);
+        assert_reduce(s2, TIdx::from(grm.terms_len()), "Expr", 1);
         assert_reduce(s3, grm.terminal_off("-"), "Term", 1);
         assert_eq!(st.action(s3, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s6));
-        assert_reduce(s3, grm.eof_term_idx(), "Term", 1);
+        assert_reduce(s3, TIdx::from(grm.terms_len()), "Term", 1);
         assert_reduce(s4, grm.terminal_off("-"), "Factor", 0);
         assert_reduce(s4, grm.terminal_off("*"), "Factor", 0);
-        assert_reduce(s4, grm.eof_term_idx(), "Factor", 0);
+        assert_reduce(s4, TIdx::from(grm.terms_len()), "Factor", 0);
         assert_eq!(st.action(s5, Symbol::Term(grm.terminal_off("id"))).unwrap(), Action::Shift(s4));
         assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("id"))).unwrap(), Action::Shift(s4));
-        assert_reduce(s7, grm.eof_term_idx(), "Expr", 0);
+        assert_reduce(s7, TIdx::from(grm.terms_len()), "Expr", 0);
         assert_reduce(s8, grm.terminal_off("-"), "Term", 0);
-        assert_reduce(s8, grm.eof_term_idx(), "Term", 0);
+        assert_reduce(s8, TIdx::from(grm.terms_len()), "Term", 0);
 
         // Gotos
         assert_eq!(st.gotos.len(), 8);
@@ -358,11 +360,11 @@ mod test {
 
         assert_eq!(st.action(s5, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(2.into()));
         assert_eq!(st.action(s5, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s5, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s5, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(2.into()));
 
         assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(1.into()));
         assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s6, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s6, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(1.into()));
     }
 
     #[test]
@@ -394,17 +396,17 @@ mod test {
         assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Shift(s3));
         assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
         assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Shift(s5));
-        assert_eq!(st.action(s6, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(3.into()));
+        assert_eq!(st.action(s6, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(3.into()));
 
         assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(2.into()));
         assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Reduce(2.into()));
         assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s7, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(2.into()));
 
         assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(1.into()));
         assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
         assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s8, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s8, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(1.into()));
     }
 
     #[test]
@@ -440,25 +442,25 @@ mod test {
         assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(4.into()));
         assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Reduce(4.into()));
         assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Reduce(4.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(4.into()));
+        assert_eq!(st.action(s7, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(4.into()));
 
         assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Shift(s3));
         assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
         assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Shift(s5));
         assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("~"))).unwrap(), Action::Shift(s6));
-        assert_eq!(st.action(s8, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(3.into()));
+        assert_eq!(st.action(s8, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(3.into()));
 
         assert_eq!(st.action(s9, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(2.into()));
         assert_eq!(st.action(s9, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Reduce(2.into()));
         assert_eq!(st.action(s9, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Reduce(2.into()));
         assert_eq!(st.action(s9, Symbol::Term(grm.terminal_off("~"))).unwrap(), Action::Shift(s6));
-        assert_eq!(st.action(s9, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s9, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(2.into()));
 
         assert_eq!(st.action(s10, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(1.into()));
         assert_eq!(st.action(s10, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
         assert_eq!(st.action(s10, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Reduce(1.into()));
         assert_eq!(st.action(s10, Symbol::Term(grm.terminal_off("~"))).unwrap(), Action::Shift(s6));
-        assert_eq!(st.action(s10, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s10, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(1.into()));
     }
 
     #[test]

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -243,50 +243,50 @@ mod test {
         assert_eq!(sg.states.len(), 9);
 
         let s0 = StIdx(0);
-        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s2 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterminal_off("Term"))];
-        let s3 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterminal_off("Factor"))];
-        let s4 = sg.edges[usize::from(s0)][&Symbol::Term(grm.terminal_off("id"))];
-        let s5 = sg.edges[usize::from(s2)][&Symbol::Term(grm.terminal_off("-"))];
-        let s6 = sg.edges[usize::from(s3)][&Symbol::Term(grm.terminal_off("*"))];
-        let s7 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s8 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterminal_off("Term"))];
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s2 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Term"))];
+        let s3 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Factor"))];
+        let s4 = sg.edges[usize::from(s0)][&Symbol::Term(grm.term_off("id"))];
+        let s5 = sg.edges[usize::from(s2)][&Symbol::Term(grm.term_off("-"))];
+        let s6 = sg.edges[usize::from(s3)][&Symbol::Term(grm.term_off("*"))];
+        let s7 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s8 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterm_off("Term"))];
 
         let st = StateTable::new(&grm, &sg).unwrap();
 
         // Actions
         assert_eq!(st.actions.len(), 15);
         let assert_reduce = |state_i: StIdx, term_i: TIdx, rule: &str, prod_off: usize| {
-            let prod_i = grm.nonterm_to_prods(grm.nonterminal_off(rule)).unwrap()[prod_off];
+            let prod_i = grm.nonterm_to_prods(grm.nonterm_off(rule)).unwrap()[prod_off];
             assert_eq!(st.action(state_i, Symbol::Term(term_i)).unwrap(), Action::Reduce(prod_i.into()));
         };
 
-        assert_eq!(st.action(s0, Symbol::Term(grm.terminal_off("id"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s0, Symbol::Term(grm.term_off("id"))).unwrap(), Action::Shift(s4));
         assert_eq!(st.action(s1, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Accept);
-        assert_eq!(st.action(s2, Symbol::Term(grm.terminal_off("-"))).unwrap(), Action::Shift(s5));
+        assert_eq!(st.action(s2, Symbol::Term(grm.term_off("-"))).unwrap(), Action::Shift(s5));
         assert_reduce(s2, TIdx::from(grm.terms_len()), "Expr", 1);
-        assert_reduce(s3, grm.terminal_off("-"), "Term", 1);
-        assert_eq!(st.action(s3, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s6));
+        assert_reduce(s3, grm.term_off("-"), "Term", 1);
+        assert_eq!(st.action(s3, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s6));
         assert_reduce(s3, TIdx::from(grm.terms_len()), "Term", 1);
-        assert_reduce(s4, grm.terminal_off("-"), "Factor", 0);
-        assert_reduce(s4, grm.terminal_off("*"), "Factor", 0);
+        assert_reduce(s4, grm.term_off("-"), "Factor", 0);
+        assert_reduce(s4, grm.term_off("*"), "Factor", 0);
         assert_reduce(s4, TIdx::from(grm.terms_len()), "Factor", 0);
-        assert_eq!(st.action(s5, Symbol::Term(grm.terminal_off("id"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("id"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s5, Symbol::Term(grm.term_off("id"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("id"))).unwrap(), Action::Shift(s4));
         assert_reduce(s7, TIdx::from(grm.terms_len()), "Expr", 0);
-        assert_reduce(s8, grm.terminal_off("-"), "Term", 0);
+        assert_reduce(s8, grm.term_off("-"), "Term", 0);
         assert_reduce(s8, TIdx::from(grm.terms_len()), "Term", 0);
 
         // Gotos
         assert_eq!(st.gotos.len(), 8);
-        assert_eq!(st.goto(s0, grm.nonterminal_off("Expr")).unwrap(), s1);
-        assert_eq!(st.goto(s0, grm.nonterminal_off("Term")).unwrap(), s2);
-        assert_eq!(st.goto(s0, grm.nonterminal_off("Factor")).unwrap(), s3);
-        assert_eq!(st.goto(s5, grm.nonterminal_off("Expr")).unwrap(), s7);
-        assert_eq!(st.goto(s5, grm.nonterminal_off("Term")).unwrap(), s2);
-        assert_eq!(st.goto(s5, grm.nonterminal_off("Factor")).unwrap(), s3);
-        assert_eq!(st.goto(s6, grm.nonterminal_off("Term")).unwrap(), s8);
-        assert_eq!(st.goto(s6, grm.nonterminal_off("Factor")).unwrap(), s3);
+        assert_eq!(st.goto(s0, grm.nonterm_off("Expr")).unwrap(), s1);
+        assert_eq!(st.goto(s0, grm.nonterm_off("Term")).unwrap(), s2);
+        assert_eq!(st.goto(s0, grm.nonterm_off("Factor")).unwrap(), s3);
+        assert_eq!(st.goto(s5, grm.nonterm_off("Expr")).unwrap(), s7);
+        assert_eq!(st.goto(s5, grm.nonterm_off("Term")).unwrap(), s2);
+        assert_eq!(st.goto(s5, grm.nonterm_off("Factor")).unwrap(), s3);
+        assert_eq!(st.goto(s6, grm.nonterm_off("Term")).unwrap(), s8);
+        assert_eq!(st.goto(s6, grm.nonterm_off("Factor")).unwrap(), s3);
     }
 
     #[test]
@@ -304,9 +304,9 @@ mod test {
 
         // We only extract the states necessary to test those rules affected by the reduce/reduce.
         let s0 = StIdx(0);
-        let s4 = sg.edges[usize::from(s0)][&Symbol::Term(grm.terminal_off("a"))];
+        let s4 = sg.edges[usize::from(s0)][&Symbol::Term(grm.term_off("a"))];
 
-        assert_eq!(st.action(s4, Symbol::Term(grm.terminal_off("x"))).unwrap(), Action::Reduce(3.into()));
+        assert_eq!(st.action(s4, Symbol::Term(grm.term_off("x"))).unwrap(), Action::Reduce(3.into()));
     }
 
     #[test]
@@ -323,17 +323,17 @@ mod test {
         assert_eq!(st.actions.len(), 15);
 
         let s0 = StIdx(0);
-        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("+"))];
-        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("*"))];
-        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s6 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("+"))];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("*"))];
+        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s6 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
 
-        assert_eq!(st.action(s5, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Shift(s3));
-        assert_eq!(st.action(s5, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s5, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Shift(s3));
+        assert_eq!(st.action(s5, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
 
-        assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Shift(s3));
-        assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Shift(s3));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
     }
 
     #[test]
@@ -352,18 +352,18 @@ mod test {
         assert_eq!(st.actions.len(), 15);
 
         let s0 = StIdx(0);
-        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("+"))];
-        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("*"))];
-        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s6 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("+"))];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("*"))];
+        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s6 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
 
-        assert_eq!(st.action(s5, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s5, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s5, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s5, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Reduce(2.into()));
         assert_eq!(st.action(s5, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(2.into()));
 
-        assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
         assert_eq!(st.action(s6, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(1.into()));
     }
 
@@ -385,27 +385,27 @@ mod test {
         assert_eq!(st.actions.len(), 24);
 
         let s0 = StIdx(0);
-        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("+"))];
-        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("*"))];
-        let s5 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("="))];
-        let s6 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s7 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s8 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("+"))];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("*"))];
+        let s5 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("="))];
+        let s6 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s7 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s8 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
 
-        assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Shift(s3));
-        assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s6, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Shift(s5));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Shift(s3));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("="))).unwrap(), Action::Shift(s5));
         assert_eq!(st.action(s6, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(3.into()));
 
-        assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("="))).unwrap(), Action::Reduce(2.into()));
         assert_eq!(st.action(s7, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(2.into()));
 
-        assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("="))).unwrap(), Action::Reduce(1.into()));
         assert_eq!(st.action(s8, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(1.into()));
     }
 
@@ -429,37 +429,37 @@ mod test {
         assert_eq!(st.actions.len(), 34);
 
         let s0 = StIdx(0);
-        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("+"))];
-        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("*"))];
-        let s5 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("="))];
-        let s6 = sg.edges[usize::from(s1)][&Symbol::Term(grm.terminal_off("~"))];
-        let s7 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s8 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s9 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
-        let s10 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterminal_off("Expr"))];
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("+"))];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("*"))];
+        let s5 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("="))];
+        let s6 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("~"))];
+        let s7 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s8 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s9 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s10 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
 
-        assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(4.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Reduce(4.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Reduce(4.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(4.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Reduce(4.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("="))).unwrap(), Action::Reduce(4.into()));
         assert_eq!(st.action(s7, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(4.into()));
 
-        assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Shift(s3));
-        assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Shift(s5));
-        assert_eq!(st.action(s8, Symbol::Term(grm.terminal_off("~"))).unwrap(), Action::Shift(s6));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Shift(s3));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("="))).unwrap(), Action::Shift(s5));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("~"))).unwrap(), Action::Shift(s6));
         assert_eq!(st.action(s8, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(3.into()));
 
-        assert_eq!(st.action(s9, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s9, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s9, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s9, Symbol::Term(grm.terminal_off("~"))).unwrap(), Action::Shift(s6));
+        assert_eq!(st.action(s9, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s9, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s9, Symbol::Term(grm.term_off("="))).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s9, Symbol::Term(grm.term_off("~"))).unwrap(), Action::Shift(s6));
         assert_eq!(st.action(s9, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(2.into()));
 
-        assert_eq!(st.action(s10, Symbol::Term(grm.terminal_off("+"))).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s10, Symbol::Term(grm.terminal_off("*"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s10, Symbol::Term(grm.terminal_off("="))).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s10, Symbol::Term(grm.terminal_off("~"))).unwrap(), Action::Shift(s6));
+        assert_eq!(st.action(s10, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s10, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s10, Symbol::Term(grm.term_off("="))).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s10, Symbol::Term(grm.term_off("~"))).unwrap(), Action::Shift(s6));
         assert_eq!(st.action(s10, Symbol::Term(TIdx::from(grm.terms_len()))).unwrap(), Action::Reduce(1.into()));
     }
 


### PR DESCRIPTION
Follows on from https://github.com/softdevteam/cfgrammar/pull/7. In lrtable we use the fact that we can store an EOF bit in contexts at `grm.terms_len()` (as discussed in the other PR).

[Also deals with the other minor changes squeezed into the last cfgrammar PR. Best to look at the commits individually.]