### PR TITLE
Update library dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,8 @@ name = "lrtable"
 path = "src/lib/mod.rs"
 
 [dependencies]
-bit-vec = "0.4.3"
+bit-vec = "0.4.4"
 getopts = "0.2.14"
-regex = "0.1.80"
 fnv = "1.0.5"
 macro-attr = "0.2.0"
 newtype_derive = "0.1.6"


### PR DESCRIPTION
Most usefully, lrtable no longer needs regex at all (that functionality is now
entirely within cfgrammar), so we can remove that dependency entirely.