### PR TITLE
Reflect that the explicit EOF term is back in cfgrammar.

### DIFF
--- a/src/lib/firsts.rs
+++ b/src/lib/firsts.rs
@@ -55,8 +55,6 @@ use cfgrammar::yacc::YaccGrammar;
 /// ```
 #[derive(Debug)]
 pub struct Firsts {
-    // Each production has grm.terms_len() + 1 bits: the bit at position grm.terms_len represents
-    // the EOF terminal.
     prod_firsts: Vec<BitVec>,
     prod_epsilons: BitVec
 }
@@ -66,7 +64,7 @@ impl Firsts {
     pub fn new(grm: &YaccGrammar) -> Firsts {
         let mut prod_firsts = Vec::with_capacity(grm.nonterms_len());
         for _ in 0..grm.nonterms_len() {
-            prod_firsts.push(BitVec::from_elem(grm.terms_len() + 1, false));
+            prod_firsts.push(BitVec::from_elem(grm.terms_len(), false));
         }
         let mut firsts = Firsts {
             prod_firsts  : prod_firsts,
@@ -180,7 +178,10 @@ mod test {
     fn has(grm: &YaccGrammar, firsts: &Firsts, rn: &str, should_be: Vec<&str>) {
         let nt_i = grm.nonterm_off(rn);
         for i in 0 .. grm.terms_len() {
-            let n = grm.term_name(i.into()).unwrap();
+            let n = match grm.term_name(i.into()) {
+                Some(n) => n,
+                None => &"<no name>"
+            };
             match should_be.iter().position(|&x| x == n) {
                 Some(_) => {
                     if !firsts.is_set(nt_i, i.into()) {

--- a/src/lib/itemset.rs
+++ b/src/lib/itemset.rs
@@ -98,7 +98,7 @@ impl Itemset {
         let mut keys_iter = self.items.keys(); // The initial todo list
         type BitVecBitSize = u32; // As of 0.4.3, BitVec only supports u32 blocks
         let mut zero_todos = BitVec::<BitVecBitSize>::from_elem(grm.prods_len(), false); // Subsequent todos
-        let mut new_ctx = BitVec::from_elem(grm.terms_len() + 1, false);
+        let mut new_ctx = BitVec::from_elem(grm.terms_len(), false);
         loop {
             let prod_i;
             let dot;
@@ -205,8 +205,8 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
-        la.set(grm.terms_len(), true);
+        let mut la = BitVec::from_elem(grm.terms_len(), false);
+        la.set(usize::from(grm.eof_term_idx()), true);
         is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
         let cls_is = is.close(&grm, &firsts);
         println!("{:?}", cls_is);
@@ -239,8 +239,8 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
-        la.set(grm.terms_len(), true);
+        let mut la = BitVec::from_elem(grm.terms_len(), false);
+        la.set(usize::from(grm.eof_term_idx()), true);
         is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
@@ -281,8 +281,8 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
-        la.set(grm.terms_len(), true);
+        let mut la = BitVec::from_elem(grm.terms_len(), false);
+        la.set(usize::from(grm.eof_term_idx()), true);
         is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
@@ -291,9 +291,9 @@ mod test {
         state_exists(&grm, &cls_is, "S", 1, 0, vec!["b", "$"]);
 
         is = Itemset::new(&grm);
-        la = BitVec::from_elem(grm.terms_len() + 1, false);
+        la = BitVec::from_elem(grm.terms_len(), false);
         la.set(usize::from(grm.term_off("b")), true);
-        la.set(grm.terms_len(), true);
+        la.set(usize::from(grm.eof_term_idx()), true);
         is.add(grm.nonterm_to_prods(grm.nonterm_off("S")).unwrap()[1], 1.into(), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "A", 0, 0, vec!["a"]);
@@ -301,7 +301,7 @@ mod test {
         state_exists(&grm, &cls_is, "A", 2, 0, vec!["a"]);
 
         is = Itemset::new(&grm);
-        la = BitVec::from_elem(grm.terms_len() + 1, false);
+        la = BitVec::from_elem(grm.terms_len(), false);
         la.set(usize::from(grm.term_off("a")), true);
         is.add(grm.nonterm_to_prods(grm.nonterm_off("A")).unwrap()[0], 1.into(), &la);
         cls_is = is.close(&grm, &firsts);
@@ -315,8 +315,8 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = BitVec::from_elem(grm.terms_len() + 1, false);
-        la.set(grm.terms_len(), true);
+        let mut la = BitVec::from_elem(grm.terms_len(), false);
+        la.set(usize::from(grm.eof_term_idx()), true);
         is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
         let cls_is = is.close(&grm, &firsts);
 

--- a/src/lib/pager.rs
+++ b/src/lib/pager.rs
@@ -156,8 +156,8 @@ pub fn pager_stategraph(grm: &YaccGrammar) -> StateGraph {
     let mut edges: Vec<HashMap<Symbol, StIdx>> = Vec::new();
 
     let mut state0 = Itemset::new(grm);
-    let mut ctx = BitVec::from_elem(grm.terms_len() + 1, false);
-    ctx.set(grm.terms_len(), true);
+    let mut ctx = BitVec::from_elem(grm.terms_len(), false);
+    ctx.set(usize::from(grm.eof_term_idx()), true);
     state0.add(grm.start_prod(), SIdx::from(0), &ctx);
     closed_states.push(None);
     core_states.push(state0);
@@ -166,13 +166,13 @@ pub fn pager_stategraph(grm: &YaccGrammar) -> StateGraph {
     // We maintain two lists of which nonterms and terms we've seen; when processing a given
     // state there's no point processing a nonterm or term more than once.
     let mut seen_nonterms = BitVec::from_elem(grm.nonterms_len(), false);
-    let mut seen_terms = BitVec::from_elem(grm.terms_len() + 1, false);
+    let mut seen_terms = BitVec::from_elem(grm.terms_len(), false);
     // new_states is used to separate out iterating over states vs. mutating it
     let mut new_states = Vec::new();
     // cnd_[nonterm|term]_weaklies represent which states are possible weakly compatible
     // matches for a given symbol.
     let mut cnd_nonterm_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(grm.nonterms_len());
-    let mut cnd_term_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(grm.terms_len() + 1);
+    let mut cnd_term_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(grm.terms_len());
     for _ in 0..grm.terms_len() + 1 { cnd_term_weaklies.push(Vec::new()); }
     for _ in 0..grm.nonterms_len() { cnd_nonterm_weaklies.push(Vec::new()); }
 

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -54,12 +54,12 @@ pub fn state_exists(grm: &YaccGrammar, is: &Itemset, nt: &str, prod_off: usize, 
 
     let ab_prod_off = grm.nonterm_to_prods(grm.nonterm_off(nt)).unwrap()[prod_off];
     let ctx = &is.items[&(ab_prod_off, dot.into())];
-    for i in 0..grm.terms_len() + 1 {
+    for i in 0..grm.terms_len() {
         let bit = ctx[i];
         let mut found = false;
         for t in la.iter() {
             let off = if t == &"$" {
-                    TIdx::from(grm.terms_len())
+                    TIdx::from(grm.eof_term_idx())
                 } else {
                     grm.term_off(t)
                 };


### PR DESCRIPTION
The minimal changes implied by https://github.com/softdevteam/cfgrammar/pull/9