### PR TITLE
Reflect changes in cfgrammar.

### DIFF
--- a/src/lib/firsts.rs
+++ b/src/lib/firsts.rs
@@ -48,10 +48,10 @@ use cfgrammar::yacc::YaccGrammar;
 /// then the following assertions (and only the following assertions) about the firsts set are
 /// correct:
 /// ```
-///   assert!(firsts.is_set(grm.nonterm_off("S"), grm.term_off("a")));
-///   assert!(firsts.is_set(grm.nonterm_off("S"), grm.term_off("b")));
-///   assert!(firsts.is_set(grm.nonterm_off("A"), grm.term_off("a")));
-///   assert!(firsts.is_epsilon_set(grm.nonterm_off("A")));
+///   assert!(firsts.is_set(grm.nonterm_idx("S").unwrap(), grm.term_idx("a").unwrap()));
+///   assert!(firsts.is_set(grm.nonterm_idx("S").unwrap(), grm.term_idx("b").unwrap()));
+///   assert!(firsts.is_set(grm.nonterm_idx("A").unwrap(), grm.term_idx("a").unwrap()));
+///   assert!(firsts.is_epsilon_set(grm.nonterm_idx("A").unwrap()));
 /// ```
 #[derive(Debug)]
 pub struct Firsts {
@@ -176,7 +176,7 @@ mod test {
     use cfgrammar::yacc::{yacc_grm, YaccGrammar, YaccKind};
 
     fn has(grm: &YaccGrammar, firsts: &Firsts, rn: &str, should_be: Vec<&str>) {
-        let nt_i = grm.nonterm_off(rn);
+        let nt_i = grm.nonterm_idx(rn).unwrap();
         for i in 0 .. grm.terms_len() {
             let n = match grm.term_name(i.into()) {
                 Some(n) => n,

--- a/src/lib/itemset.rs
+++ b/src/lib/itemset.rs
@@ -207,7 +207,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = BitVec::from_elem(grm.terms_len(), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap()).unwrap()[0], 0.into(), &la);
         let cls_is = is.close(&grm, &firsts);
         println!("{:?}", cls_is);
         assert_eq!(cls_is.items.len(), 6);
@@ -241,7 +241,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = BitVec::from_elem(grm.terms_len(), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap()).unwrap()[0], 0.into(), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
         state_exists(&grm, &cls_is, "^", 0, 0, vec!["$"]);
@@ -250,7 +250,7 @@ mod test {
         state_exists(&grm, &cls_is, "S", 2, 0, vec!["b", "$"]);
 
         is = Itemset::new(&grm);
-        is.add(grm.nonterm_to_prods(grm.nonterm_off("F")).unwrap()[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("F").unwrap()).unwrap()[0], 0.into(), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "F", 0, 0, vec!["$"]);
         state_exists(&grm, &cls_is, "C", 0, 0, vec!["d", "f"]);
@@ -283,7 +283,7 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = BitVec::from_elem(grm.terms_len(), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap()).unwrap()[0], 0.into(), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
         state_exists(&grm, &cls_is, "^", 0, 0, vec!["$"]);
@@ -292,9 +292,9 @@ mod test {
 
         is = Itemset::new(&grm);
         la = BitVec::from_elem(grm.terms_len(), false);
-        la.set(usize::from(grm.term_off("b")), true);
+        la.set(usize::from(grm.term_idx("b").unwrap()), true);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_off("S")).unwrap()[1], 1.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("S").unwrap()).unwrap()[1], 1.into(), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "A", 0, 0, vec!["a"]);
         state_exists(&grm, &cls_is, "A", 1, 0, vec!["a"]);
@@ -302,8 +302,8 @@ mod test {
 
         is = Itemset::new(&grm);
         la = BitVec::from_elem(grm.terms_len(), false);
-        la.set(usize::from(grm.term_off("a")), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_off("A")).unwrap()[0], 1.into(), &la);
+        la.set(usize::from(grm.term_idx("a").unwrap()), true);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("A").unwrap()).unwrap()[0], 1.into(), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "S", 0, 0, vec!["b", "c"]);
         state_exists(&grm, &cls_is, "S", 1, 0, vec!["b", "c"]);
@@ -317,19 +317,19 @@ mod test {
         let mut is = Itemset::new(&grm);
         let mut la = BitVec::from_elem(grm.terms_len(), false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_off("^")).unwrap()[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap()).unwrap()[0], 0.into(), &la);
         let cls_is = is.close(&grm, &firsts);
 
-        let goto1 = cls_is.goto(&grm, &Symbol::Nonterm(grm.nonterm_off("S")));
+        let goto1 = cls_is.goto(&grm, &Symbol::Nonterm(grm.nonterm_idx("S").unwrap()));
         state_exists(&grm, &goto1, "^", 0, 1, vec!["$"]);
         state_exists(&grm, &goto1, "S", 0, 1, vec!["$", "b"]);
 
         // follow 'b' from start set
-        let goto2 = cls_is.goto(&grm, &Symbol::Term(grm.term_off("b")));
+        let goto2 = cls_is.goto(&grm, &Symbol::Term(grm.term_idx("b").unwrap()));
         state_exists(&grm, &goto2, "S", 1, 1, vec!["$", "b"]);
 
         // continue by following 'a' from last goto, after it's been closed
-        let goto3 = goto2.close(&grm, &firsts).goto(&grm, &Symbol::Term(grm.term_off("a")));
+        let goto3 = goto2.close(&grm, &firsts).goto(&grm, &Symbol::Term(grm.term_idx("a").unwrap()));
         state_exists(&grm, &goto3, "A", 1, 1, vec!["a"]);
         state_exists(&grm, &goto3, "A", 2, 1, vec!["a"]);
     }

--- a/src/lib/pager.rs
+++ b/src/lib/pager.rs
@@ -429,33 +429,33 @@ mod test {
         state_exists(&grm, &sg.states[0], "S", 0, 0, vec!["$", "b"]);
         state_exists(&grm, &sg.states[0], "S", 1, 0, vec!["$", "b"]);
 
-        let s1 = sg.edges[0][&Symbol::Nonterm(grm.nonterm_off("S"))];
+        let s1 = sg.edges[0][&Symbol::Nonterm(grm.nonterm_idx("S").unwrap())];
         assert_eq!(sg.states[usize::from(s1)].items.len(), 2);
         state_exists(&grm, &sg.states[usize::from(s1)], "^", 0, 1, vec!["$"]);
         state_exists(&grm, &sg.states[usize::from(s1)], "S", 0, 1, vec!["$", "b"]);
 
-        let s2 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("b"))];
+        let s2 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("b").unwrap())];
         assert_eq!(sg.states[usize::from(s2)].items.len(), 1);
         state_exists(&grm, &sg.states[usize::from(s2)], "S", 0, 2, vec!["$", "b"]);
 
-        let s3 = sg.edges[0][&Symbol::Term(grm.term_off("b"))];
+        let s3 = sg.edges[0][&Symbol::Term(grm.term_idx("b").unwrap())];
         assert_eq!(sg.states[usize::from(s3)].items.len(), 4);
         state_exists(&grm, &sg.states[usize::from(s3)], "S", 1, 1, vec!["$", "b", "c"]);
         state_exists(&grm, &sg.states[usize::from(s3)], "A", 0, 0, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s3)], "A", 1, 0, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s3)], "A", 2, 0, vec!["a"]);
 
-        let s4 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("A"))];
+        let s4 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_idx("A").unwrap())];
         assert_eq!(sg.states[usize::from(s4)].items.len(), 1);
         state_exists(&grm, &sg.states[usize::from(s4)], "S", 1, 2, vec!["$", "b", "c"]);
 
-        let s5 = sg.edges[usize::from(s4)][&Symbol::Term(grm.term_off("a"))];
+        let s5 = sg.edges[usize::from(s4)][&Symbol::Term(grm.term_idx("a").unwrap())];
         assert_eq!(sg.states[usize::from(s5)].items.len(), 1);
         state_exists(&grm, &sg.states[usize::from(s5)], "S", 1, 3, vec!["$", "b", "c"]);
 
-        let s6 = sg.edges[usize::from(s3)][&Symbol::Term(grm.term_off("a"))];
+        let s6 = sg.edges[usize::from(s3)][&Symbol::Term(grm.term_idx("a").unwrap())];
         // result from merging 10 into 3
-        assert_eq!(s3, sg.edges[usize::from(s6)][&Symbol::Term(grm.term_off("b"))]);
+        assert_eq!(s3, sg.edges[usize::from(s6)][&Symbol::Term(grm.term_idx("b").unwrap())]);
         assert_eq!(sg.states[usize::from(s6)].items.len(), 5);
         state_exists(&grm, &sg.states[usize::from(s6)], "A", 0, 1, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s6)], "A", 1, 1, vec!["a"]);
@@ -463,17 +463,17 @@ mod test {
         state_exists(&grm, &sg.states[usize::from(s6)], "S", 0, 0, vec!["b", "c"]);
         state_exists(&grm, &sg.states[usize::from(s6)], "S", 1, 0, vec!["b", "c"]);
 
-        let s7 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterm_off("S"))];
+        let s7 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterm_idx("S").unwrap())];
         assert_eq!(sg.states[usize::from(s7)].items.len(), 3);
         state_exists(&grm, &sg.states[usize::from(s7)], "A", 0, 2, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s7)], "A", 2, 2, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s7)], "S", 0, 1, vec!["b", "c"]);
 
-        let s8 = sg.edges[usize::from(s7)][&Symbol::Term(grm.term_off("c"))];
+        let s8 = sg.edges[usize::from(s7)][&Symbol::Term(grm.term_idx("c").unwrap())];
         assert_eq!(sg.states[usize::from(s8)].items.len(), 1);
         state_exists(&grm, &sg.states[usize::from(s8)], "A", 0, 3, vec!["a"]);
 
-        let s9 = sg.edges[usize::from(s7)][&Symbol::Term(grm.term_off("b"))];
+        let s9 = sg.edges[usize::from(s7)][&Symbol::Term(grm.term_idx("b").unwrap())];
         assert_eq!(sg.states[usize::from(s9)].items.len(), 2);
         state_exists(&grm, &sg.states[usize::from(s9)], "A", 2, 3, vec!["a"]);
         state_exists(&grm, &sg.states[usize::from(s9)], "S", 0, 2, vec!["b", "c"]);
@@ -509,7 +509,7 @@ mod test {
         state_exists(&grm, &sg.states[0], "X", 4, 0, vec!["$"]);
         state_exists(&grm, &sg.states[0], "X", 5, 0, vec!["$"]);
 
-        let s1 = sg.edges[0][&Symbol::Term(grm.term_off("a"))];
+        let s1 = sg.edges[0][&Symbol::Term(grm.term_idx("a").unwrap())];
         assert_eq!(sg.states[usize::from(s1)].items.len(), 7);
         state_exists(&grm, &sg.states[usize::from(s1)], "X", 0, 1, vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.states[usize::from(s1)], "X", 1, 1, vec!["a", "d", "e", "$"]);
@@ -519,7 +519,7 @@ mod test {
         state_exists(&grm, &sg.states[usize::from(s1)], "Z", 0, 0, vec!["c"]);
         state_exists(&grm, &sg.states[usize::from(s1)], "T", 0, 0, vec!["a", "d", "e", "$"]);
 
-        let s7 = sg.edges[0][&Symbol::Term(grm.term_off("b"))];
+        let s7 = sg.edges[0][&Symbol::Term(grm.term_idx("b").unwrap())];
         assert_eq!(sg.states[usize::from(s7)].items.len(), 7);
         state_exists(&grm, &sg.states[usize::from(s7)], "X", 3, 1, vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.states[usize::from(s7)], "X", 4, 1, vec!["a", "d", "e", "$"]);
@@ -529,9 +529,9 @@ mod test {
         state_exists(&grm, &sg.states[usize::from(s1)], "Z", 0, 0, vec!["c"]);
         state_exists(&grm, &sg.states[usize::from(s1)], "T", 0, 0, vec!["a", "d", "e", "$"]);
 
-        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("u"))];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("u").unwrap())];
         assert_eq!(sg.states[usize::from(s4)].items.len(), 8);
-        assert_eq!(s4, sg.edges[usize::from(s7)][&Symbol::Term(grm.term_off("u"))]);
+        assert_eq!(s4, sg.edges[usize::from(s7)][&Symbol::Term(grm.term_idx("u").unwrap())]);
         state_exists(&grm, &sg.states[usize::from(s4)], "Y", 1, 1, vec!["d", "e"]);
         state_exists(&grm, &sg.states[usize::from(s4)], "T", 0, 1, vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.states[usize::from(s4)], "X", 0, 0, vec!["a", "d", "e"]);
@@ -541,37 +541,37 @@ mod test {
         state_exists(&grm, &sg.states[usize::from(s4)], "X", 4, 0, vec!["a", "d", "e"]);
         state_exists(&grm, &sg.states[usize::from(s4)], "X", 5, 0, vec!["a", "d", "e"]);
 
-        assert_eq!(s1, sg.edges[usize::from(s4)][&Symbol::Term(grm.term_off("a"))]);
-        assert_eq!(s7, sg.edges[usize::from(s4)][&Symbol::Term(grm.term_off("b"))]);
+        assert_eq!(s1, sg.edges[usize::from(s4)][&Symbol::Term(grm.term_idx("a").unwrap())]);
+        assert_eq!(s7, sg.edges[usize::from(s4)][&Symbol::Term(grm.term_idx("b").unwrap())]);
 
-        let s2 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("t"))];
+        let s2 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("t").unwrap())];
         assert_eq!(sg.states[usize::from(s2)].items.len(), 3);
         state_exists(&grm, &sg.states[usize::from(s2)], "Y", 0, 1, vec!["d"]);
         state_exists(&grm, &sg.states[usize::from(s2)], "Z", 0, 1, vec!["c"]);
         state_exists(&grm, &sg.states[usize::from(s2)], "W", 0, 0, vec!["d"]);
 
-        let s3 = sg.edges[usize::from(s2)][&Symbol::Term(grm.term_off("u"))];
+        let s3 = sg.edges[usize::from(s2)][&Symbol::Term(grm.term_idx("u").unwrap())];
         assert_eq!(sg.states[usize::from(s3)].items.len(), 3);
         state_exists(&grm, &sg.states[usize::from(s3)], "Z", 0, 2, vec!["c"]);
         state_exists(&grm, &sg.states[usize::from(s3)], "W", 0, 1, vec!["d"]);
         state_exists(&grm, &sg.states[usize::from(s3)], "V", 0, 0, vec!["d"]);
 
-        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_off("X"))];
+        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_idx("X").unwrap())];
         assert_eq!(sg.states[usize::from(s5)].items.len(), 2);
         state_exists(&grm, &sg.states[usize::from(s5)], "Y", 1, 2, vec!["d", "e"]);
         state_exists(&grm, &sg.states[usize::from(s5)], "T", 0, 2, vec!["a", "d", "e", "$"]);
 
-        let s6 = sg.edges[usize::from(s5)][&Symbol::Term(grm.term_off("a"))];
+        let s6 = sg.edges[usize::from(s5)][&Symbol::Term(grm.term_idx("a").unwrap())];
         assert_eq!(sg.states[usize::from(s6)].items.len(), 1);
         state_exists(&grm, &sg.states[usize::from(s6)], "T", 0, 3, vec!["a", "d", "e", "$"]);
 
-        let s8 = sg.edges[usize::from(s7)][&Symbol::Term(grm.term_off("t"))];
+        let s8 = sg.edges[usize::from(s7)][&Symbol::Term(grm.term_idx("t").unwrap())];
         assert_eq!(sg.states[usize::from(s8)].items.len(), 3);
         state_exists(&grm, &sg.states[usize::from(s8)], "Y", 0, 1, vec!["e"]);
         state_exists(&grm, &sg.states[usize::from(s8)], "Z", 0, 1, vec!["d"]);
         state_exists(&grm, &sg.states[usize::from(s8)], "W", 0, 0, vec!["e"]);
 
-        let s9 = sg.edges[usize::from(s8)][&Symbol::Term(grm.term_off("u"))];
+        let s9 = sg.edges[usize::from(s8)][&Symbol::Term(grm.term_idx("u").unwrap())];
         assert_eq!(sg.states[usize::from(s9)].items.len(), 3);
         state_exists(&grm, &sg.states[usize::from(s9)], "Z", 0, 2, vec!["d"]);
         state_exists(&grm, &sg.states[usize::from(s9)], "W", 0, 1, vec!["e"]);
@@ -580,49 +580,49 @@ mod test {
         // Ommitted successors from the graph in Fig.3
 
         // X-successor of S0
-        let s0x = sg.edges[0][&Symbol::Nonterm(grm.nonterm_off("X"))];
+        let s0x = sg.edges[0][&Symbol::Nonterm(grm.nonterm_idx("X").unwrap())];
         state_exists(&grm, &sg.states[usize::from(s0x)], "^", 0, 1, vec!["$"]);
 
         // Y-successor of S1 (and it's d-successor)
-        let s1y = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterm_off("Y"))];
+        let s1y = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterm_idx("Y").unwrap())];
         state_exists(&grm, &sg.states[usize::from(s1y)], "X", 0, 2, vec!["a", "d", "e", "$"]);
-        let s1yd = sg.edges[usize::from(s1y)][&Symbol::Term(grm.term_off("d"))];
+        let s1yd = sg.edges[usize::from(s1y)][&Symbol::Term(grm.term_idx("d").unwrap())];
         state_exists(&grm, &sg.states[usize::from(s1yd)], "X", 0, 3, vec!["a", "d", "e", "$"]);
 
         // Z-successor of S1 (and it's successor)
-        let s1z = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterm_off("Z"))];
+        let s1z = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterm_idx("Z").unwrap())];
         state_exists(&grm, &sg.states[usize::from(s1z)], "X", 1, 2, vec!["a", "d", "e", "$"]);
-        let s1zc = sg.edges[usize::from(s1z)][&Symbol::Term(grm.term_off("c"))];
+        let s1zc = sg.edges[usize::from(s1z)][&Symbol::Term(grm.term_idx("c").unwrap())];
         state_exists(&grm, &sg.states[usize::from(s1zc)], "X", 1, 3, vec!["a", "d", "e", "$"]);
 
         // T-successor of S1
-        let s1t = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterm_off("T"))];
+        let s1t = sg.edges[usize::from(s1)][&Symbol::Nonterm(grm.nonterm_idx("T").unwrap())];
         state_exists(&grm, &sg.states[usize::from(s1t)], "X", 2, 2, vec!["a", "d", "e", "$"]);
 
         // Y-successor of S7 (and it's d-successor)
-        let s7y = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterm_off("Y"))];
+        let s7y = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterm_idx("Y").unwrap())];
         state_exists(&grm, &sg.states[usize::from(s7y)], "X", 3, 2, vec!["a", "d", "e", "$"]);
-        let s7ye = sg.edges[usize::from(s7y)][&Symbol::Term(grm.term_off("e"))];
+        let s7ye = sg.edges[usize::from(s7y)][&Symbol::Term(grm.term_idx("e").unwrap())];
         state_exists(&grm, &sg.states[usize::from(s7ye)], "X", 3, 3, vec!["a", "d", "e", "$"]);
 
         // Z-successor of S7 (and it's successor)
-        let s7z = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterm_off("Z"))];
+        let s7z = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterm_idx("Z").unwrap())];
         state_exists(&grm, &sg.states[usize::from(s7z)], "X", 4, 2, vec!["a", "d", "e", "$"]);
-        let s7zd = sg.edges[usize::from(s7z)][&Symbol::Term(grm.term_off("d"))];
+        let s7zd = sg.edges[usize::from(s7z)][&Symbol::Term(grm.term_idx("d").unwrap())];
         state_exists(&grm, &sg.states[usize::from(s7zd)], "X", 4, 3, vec!["a", "d", "e", "$"]);
 
         // T-successor of S7
-        let s7t = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterm_off("T"))];
+        let s7t = sg.edges[usize::from(s7)][&Symbol::Nonterm(grm.nonterm_idx("T").unwrap())];
         state_exists(&grm, &sg.states[usize::from(s7t)], "X", 5, 2, vec!["a", "d", "e", "$"]);
 
         // W-successor of S2 and S8 (merged)
-        let s8w = sg.edges[usize::from(s8)][&Symbol::Nonterm(grm.nonterm_off("W"))];
-        assert_eq!(s8w, sg.edges[usize::from(s2)][&Symbol::Nonterm(grm.nonterm_off("W"))]);
+        let s8w = sg.edges[usize::from(s8)][&Symbol::Nonterm(grm.nonterm_idx("W").unwrap())];
+        assert_eq!(s8w, sg.edges[usize::from(s2)][&Symbol::Nonterm(grm.nonterm_idx("W").unwrap())]);
         state_exists(&grm, &sg.states[usize::from(s8w)], "Y", 0, 2, vec!["d", "e"]);
 
         // V-successor of S3 and S9 (merged)
-        let s9v = sg.edges[usize::from(s9)][&Symbol::Nonterm(grm.nonterm_off("V"))];
-        assert_eq!(s9v, sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("V"))]);
+        let s9v = sg.edges[usize::from(s9)][&Symbol::Nonterm(grm.nonterm_idx("V").unwrap())];
+        assert_eq!(s9v, sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_idx("V").unwrap())]);
         state_exists(&grm, &sg.states[usize::from(s9v)], "W", 0, 2, vec!["d", "e"]);
     }
 

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -52,7 +52,7 @@ use cfgrammar::yacc::YaccGrammar;
 pub fn state_exists(grm: &YaccGrammar, is: &Itemset, nt: &str, prod_off: usize, dot: usize, la:
                     Vec<&str>) {
 
-    let ab_prod_off = grm.nonterm_to_prods(grm.nonterm_off(nt)).unwrap()[prod_off];
+    let ab_prod_off = grm.nonterm_to_prods(grm.nonterm_idx(nt).unwrap()).unwrap()[prod_off];
     let ctx = &is.items[&(ab_prod_off, dot.into())];
     for i in 0..grm.terms_len() {
         let bit = ctx[i];
@@ -61,7 +61,7 @@ pub fn state_exists(grm: &YaccGrammar, is: &Itemset, nt: &str, prod_off: usize, 
             let off = if t == &"$" {
                     TIdx::from(grm.eof_term_idx())
                 } else {
-                    grm.term_off(t)
+                    grm.term_idx(t).unwrap()
                 };
             if off == i.into() {
                 if !bit {

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -241,50 +241,50 @@ mod test {
         assert_eq!(sg.states.len(), 9);
 
         let s0 = StIdx(0);
-        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s2 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Term"))];
-        let s3 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Factor"))];
-        let s4 = sg.edges[usize::from(s0)][&Symbol::Term(grm.term_off("id"))];
-        let s5 = sg.edges[usize::from(s2)][&Symbol::Term(grm.term_off("-"))];
-        let s6 = sg.edges[usize::from(s3)][&Symbol::Term(grm.term_off("*"))];
-        let s7 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s8 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterm_off("Term"))];
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s2 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_idx("Term").unwrap())];
+        let s3 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_idx("Factor").unwrap())];
+        let s4 = sg.edges[usize::from(s0)][&Symbol::Term(grm.term_idx("id").unwrap())];
+        let s5 = sg.edges[usize::from(s2)][&Symbol::Term(grm.term_idx("-").unwrap())];
+        let s6 = sg.edges[usize::from(s3)][&Symbol::Term(grm.term_idx("*").unwrap())];
+        let s7 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s8 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterm_idx("Term").unwrap())];
 
         let st = StateTable::new(&grm, &sg).unwrap();
 
         // Actions
         assert_eq!(st.actions.len(), 15);
         let assert_reduce = |state_i: StIdx, term_i: TIdx, rule: &str, prod_off: usize| {
-            let prod_i = grm.nonterm_to_prods(grm.nonterm_off(rule)).unwrap()[prod_off];
+            let prod_i = grm.nonterm_to_prods(grm.nonterm_idx(rule).unwrap()).unwrap()[prod_off];
             assert_eq!(st.action(state_i, Symbol::Term(term_i)).unwrap(), Action::Reduce(prod_i.into()));
         };
 
-        assert_eq!(st.action(s0, Symbol::Term(grm.term_off("id"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s0, Symbol::Term(grm.term_idx("id").unwrap())).unwrap(), Action::Shift(s4));
         assert_eq!(st.action(s1, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Accept);
-        assert_eq!(st.action(s2, Symbol::Term(grm.term_off("-"))).unwrap(), Action::Shift(s5));
+        assert_eq!(st.action(s2, Symbol::Term(grm.term_idx("-").unwrap())).unwrap(), Action::Shift(s5));
         assert_reduce(s2, grm.eof_term_idx(), "Expr", 1);
-        assert_reduce(s3, grm.term_off("-"), "Term", 1);
-        assert_eq!(st.action(s3, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s6));
+        assert_reduce(s3, grm.term_idx("-").unwrap(), "Term", 1);
+        assert_eq!(st.action(s3, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s6));
         assert_reduce(s3, grm.eof_term_idx(), "Term", 1);
-        assert_reduce(s4, grm.term_off("-"), "Factor", 0);
-        assert_reduce(s4, grm.term_off("*"), "Factor", 0);
+        assert_reduce(s4, grm.term_idx("-").unwrap(), "Factor", 0);
+        assert_reduce(s4, grm.term_idx("*").unwrap(), "Factor", 0);
         assert_reduce(s4, grm.eof_term_idx(), "Factor", 0);
-        assert_eq!(st.action(s5, Symbol::Term(grm.term_off("id"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("id"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s5, Symbol::Term(grm.term_idx("id").unwrap())).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("id").unwrap())).unwrap(), Action::Shift(s4));
         assert_reduce(s7, grm.eof_term_idx(), "Expr", 0);
-        assert_reduce(s8, grm.term_off("-"), "Term", 0);
+        assert_reduce(s8, grm.term_idx("-").unwrap(), "Term", 0);
         assert_reduce(s8, grm.eof_term_idx(), "Term", 0);
 
         // Gotos
         assert_eq!(st.gotos.len(), 8);
-        assert_eq!(st.goto(s0, grm.nonterm_off("Expr")).unwrap(), s1);
-        assert_eq!(st.goto(s0, grm.nonterm_off("Term")).unwrap(), s2);
-        assert_eq!(st.goto(s0, grm.nonterm_off("Factor")).unwrap(), s3);
-        assert_eq!(st.goto(s5, grm.nonterm_off("Expr")).unwrap(), s7);
-        assert_eq!(st.goto(s5, grm.nonterm_off("Term")).unwrap(), s2);
-        assert_eq!(st.goto(s5, grm.nonterm_off("Factor")).unwrap(), s3);
-        assert_eq!(st.goto(s6, grm.nonterm_off("Term")).unwrap(), s8);
-        assert_eq!(st.goto(s6, grm.nonterm_off("Factor")).unwrap(), s3);
+        assert_eq!(st.goto(s0, grm.nonterm_idx("Expr").unwrap()).unwrap(), s1);
+        assert_eq!(st.goto(s0, grm.nonterm_idx("Term").unwrap()).unwrap(), s2);
+        assert_eq!(st.goto(s0, grm.nonterm_idx("Factor").unwrap()).unwrap(), s3);
+        assert_eq!(st.goto(s5, grm.nonterm_idx("Expr").unwrap()).unwrap(), s7);
+        assert_eq!(st.goto(s5, grm.nonterm_idx("Term").unwrap()).unwrap(), s2);
+        assert_eq!(st.goto(s5, grm.nonterm_idx("Factor").unwrap()).unwrap(), s3);
+        assert_eq!(st.goto(s6, grm.nonterm_idx("Term").unwrap()).unwrap(), s8);
+        assert_eq!(st.goto(s6, grm.nonterm_idx("Factor").unwrap()).unwrap(), s3);
     }
 
     #[test]
@@ -302,9 +302,9 @@ mod test {
 
         // We only extract the states necessary to test those rules affected by the reduce/reduce.
         let s0 = StIdx(0);
-        let s4 = sg.edges[usize::from(s0)][&Symbol::Term(grm.term_off("a"))];
+        let s4 = sg.edges[usize::from(s0)][&Symbol::Term(grm.term_idx("a").unwrap())];
 
-        assert_eq!(st.action(s4, Symbol::Term(grm.term_off("x"))).unwrap(), Action::Reduce(3.into()));
+        assert_eq!(st.action(s4, Symbol::Term(grm.term_idx("x").unwrap())).unwrap(), Action::Reduce(3.into()));
     }
 
     #[test]
@@ -321,17 +321,17 @@ mod test {
         assert_eq!(st.actions.len(), 15);
 
         let s0 = StIdx(0);
-        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("+"))];
-        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("*"))];
-        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s6 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("+").unwrap())];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("*").unwrap())];
+        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s6 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
 
-        assert_eq!(st.action(s5, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Shift(s3));
-        assert_eq!(st.action(s5, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s5, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Shift(s3));
+        assert_eq!(st.action(s5, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
 
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Shift(s3));
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Shift(s3));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
     }
 
     #[test]
@@ -350,18 +350,18 @@ mod test {
         assert_eq!(st.actions.len(), 15);
 
         let s0 = StIdx(0);
-        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("+"))];
-        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("*"))];
-        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s6 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("+").unwrap())];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("*").unwrap())];
+        let s5 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s6 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
 
-        assert_eq!(st.action(s5, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s5, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s5, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s5, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Reduce(2.into()));
         assert_eq!(st.action(s5, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(2.into()));
 
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
         assert_eq!(st.action(s6, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(1.into()));
     }
 
@@ -383,27 +383,27 @@ mod test {
         assert_eq!(st.actions.len(), 24);
 
         let s0 = StIdx(0);
-        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("+"))];
-        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("*"))];
-        let s5 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("="))];
-        let s6 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s7 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s8 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("+").unwrap())];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("*").unwrap())];
+        let s5 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("=").unwrap())];
+        let s6 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s7 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s8 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
 
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Shift(s3));
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_off("="))).unwrap(), Action::Shift(s5));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Shift(s3));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Shift(s5));
         assert_eq!(st.action(s6, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(3.into()));
 
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("="))).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Reduce(2.into()));
         assert_eq!(st.action(s7, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(2.into()));
 
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("="))).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Reduce(1.into()));
         assert_eq!(st.action(s8, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(1.into()));
     }
 
@@ -427,37 +427,37 @@ mod test {
         assert_eq!(st.actions.len(), 34);
 
         let s0 = StIdx(0);
-        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("+"))];
-        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("*"))];
-        let s5 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("="))];
-        let s6 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_off("~"))];
-        let s7 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s8 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s9 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
-        let s10 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_off("Expr"))];
+        let s1 = sg.edges[usize::from(s0)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s3 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("+").unwrap())];
+        let s4 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("*").unwrap())];
+        let s5 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("=").unwrap())];
+        let s6 = sg.edges[usize::from(s1)][&Symbol::Term(grm.term_idx("~").unwrap())];
+        let s7 = sg.edges[usize::from(s6)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s8 = sg.edges[usize::from(s5)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s9 = sg.edges[usize::from(s4)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
+        let s10 = sg.edges[usize::from(s3)][&Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())];
 
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(4.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Reduce(4.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_off("="))).unwrap(), Action::Reduce(4.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(4.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Reduce(4.into()));
+        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Reduce(4.into()));
         assert_eq!(st.action(s7, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(4.into()));
 
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Shift(s3));
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("="))).unwrap(), Action::Shift(s5));
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_off("~"))).unwrap(), Action::Shift(s6));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Shift(s3));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Shift(s5));
+        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("~").unwrap())).unwrap(), Action::Shift(s6));
         assert_eq!(st.action(s8, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(3.into()));
 
-        assert_eq!(st.action(s9, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s9, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s9, Symbol::Term(grm.term_off("="))).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s9, Symbol::Term(grm.term_off("~"))).unwrap(), Action::Shift(s6));
+        assert_eq!(st.action(s9, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s9, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s9, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s9, Symbol::Term(grm.term_idx("~").unwrap())).unwrap(), Action::Shift(s6));
         assert_eq!(st.action(s9, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(2.into()));
 
-        assert_eq!(st.action(s10, Symbol::Term(grm.term_off("+"))).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s10, Symbol::Term(grm.term_off("*"))).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s10, Symbol::Term(grm.term_off("="))).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s10, Symbol::Term(grm.term_off("~"))).unwrap(), Action::Shift(s6));
+        assert_eq!(st.action(s10, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s10, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
+        assert_eq!(st.action(s10, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s10, Symbol::Term(grm.term_idx("~").unwrap())).unwrap(), Action::Shift(s6));
         assert_eq!(st.action(s10, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(1.into()));
     }
 


### PR DESCRIPTION
[non]term_off is now [non]term_idx (and now returns `Option`). This is a mechanical change (I used `srep` for it).

[I should have made this PR a few days ago, but somehow forgot!]