### PR TITLE
Sparse table for actions

### DIFF
--- a/src/lib/itemset.rs
+++ b/src/lib/itemset.rs
@@ -36,12 +36,11 @@ use std::hash::BuildHasherDefault;
 extern crate bit_vec;
 use self::bit_vec::{BitBlock, BitVec};
 
-extern crate fnv;
-use self::fnv::FnvHasher;
-
-use firsts::Firsts;
 use cfgrammar::{Grammar, PIdx, Symbol, SIdx};
 use cfgrammar::yacc::YaccGrammar;
+use fnv::FnvHasher;
+
+use firsts::Firsts;
 
 /// The type of "context" (also known as "lookaheads")
 pub type Ctx = BitVec;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -35,6 +35,7 @@
 #[macro_use] extern crate macro_attr;
 #[macro_use] extern crate newtype_derive;
 extern crate cfgrammar;
+extern crate fnv;
 
 mod firsts;
 mod itemset;

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -31,11 +31,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use std::collections::hash_map::{Entry, HashMap, OccupiedEntry};
+use std::hash::BuildHasherDefault;
 use std::fmt;
 
-use StIdx;
 use cfgrammar::{Grammar, PIdx, NTIdx, Symbol, TIdx};
 use cfgrammar::yacc::{AssocKind, YaccGrammar};
+use fnv::FnvHasher;
+
+use StIdx;
 use stategraph::StateGraph;
 
 /// The various different possible Yacc parser errors.
@@ -72,7 +75,7 @@ pub struct StateTable {
     //   0  shift 1
     //   1  shift 0  reduce B
     // is represented as a hashtable {0: shift 1, 2: shift 0, 3: reduce 4}.
-    actions          : HashMap<usize, Action>,
+    actions          : HashMap<usize, Action, BuildHasherDefault<FnvHasher>>,
     gotos            : HashMap<(StIdx, NTIdx), StIdx>,
     terms_len        : usize,
     /// The number of reduce/reduce errors encountered.
@@ -93,8 +96,8 @@ pub enum Action {
 
 impl StateTable {
     pub fn new(grm: &YaccGrammar, sg: &StateGraph) -> Result<StateTable, StateTableError> {
-        let mut actions: HashMap<usize, Action> = HashMap::new();
-        let mut gotos  : HashMap<(StIdx, NTIdx), StIdx>   = HashMap::new();
+        let mut actions = HashMap::with_hasher(BuildHasherDefault::<FnvHasher>::default());
+        let mut gotos   = HashMap::new();
         let mut reduce_reduce = 0; // How many automatically resolved reduce/reduces were made?
         let mut shift_reduce  = 0; // How many automatically resolved shift/reduces were made?
 


### PR DESCRIPTION
Previously we represented actions as a mapping from a tuple (state index1, non-terminal index) -> state index2. In other words, if you were in "state index1" and encountered a non-terminal, you could look up which state you should move to next.

This works well enough for normal parsing, but not for error recovery, where one often needs to know "which non-terminals are valid actions for state S?" This PR cheats a little, changing the mapping to state table offset -> state index. We use the normal statetable representation where rows represent states and columns represent terminals. Thus the statetable:

```
          A         B
     0  shift 1
     1  shift 0  reduce B
```

is represented as a hashtable `{0: shift 1, 2: shift 0, 3: reduce 4}`. This allows us to do a faster (although still not far from optimal) version of "which non-terminals are valid actions for state S?", which speeds error recovery up significantly (e.g. on the Java grammar, such queries are tens of thousands time faster).

In the long term we should move to a more appropriate, and compact, sparse table representation. That's not a small job, so this should do in the meantime, however.