### PR TITLE
Newtype changes

### DIFF
--- a/src/lib/firsts.rs
+++ b/src/lib/firsts.rs
@@ -61,13 +61,13 @@ pub struct Firsts {
 impl Firsts {
     /// Generates and returns the firsts set for the given grammar.
     pub fn new(grm: &YaccGrammar) -> Firsts {
-        let mut prod_firsts = Vec::with_capacity(grm.nonterms_len());
+        let mut prod_firsts = Vec::with_capacity(grm.nonterms_len() as usize);
         for _ in 0..grm.nonterms_len() {
-            prod_firsts.push(Vob::from_elem(grm.terms_len(), false));
+            prod_firsts.push(Vob::from_elem(grm.terms_len() as usize, false));
         }
         let mut firsts = Firsts {
             prod_firsts  : prod_firsts,
-            prod_epsilons: Vob::from_elem(grm.nonterms_len(), false),
+            prod_epsilons: Vob::from_elem(grm.nonterms_len() as usize, false),
         };
 
         // Loop looking for changes to the firsts set, until we reach a fixed point. In essence, we

--- a/src/lib/itemset.rs
+++ b/src/lib/itemset.rs
@@ -93,8 +93,8 @@ impl Itemset {
         // continually iterate over the bitfield from 2 until no new items have been added.
 
         let mut keys_iter = self.items.keys(); // The initial todo list
-        let mut zero_todos = Vob::from_elem(grm.prods_len(), false); // Subsequent todos
-        let mut new_ctx = Vob::from_elem(grm.terms_len(), false);
+        let mut zero_todos = Vob::from_elem(grm.prods_len() as usize, false); // Subsequent todos
+        let mut new_ctx = Vob::from_elem(grm.terms_len() as usize, false);
         loop {
             let prod_i;
             let dot;
@@ -111,7 +111,7 @@ impl Itemset {
                         Some(i) => prod_i = PIdx::from(i),
                         None => break
                     }
-                    dot = 0.into();
+                    dot = SIdx::from(0 as u32);
                     zero_todos.set(prod_i.into(), false);
                 }
             }
@@ -147,7 +147,7 @@ impl Itemset {
                 }
 
                 for ref_prod_i in grm.nonterm_to_prods(nonterm_i).iter() {
-                    if new_is.add(*ref_prod_i, 0.into(), &new_ctx) {
+                    if new_is.add(*ref_prod_i, SIdx::from(0 as u32), &new_ctx) {
                         zero_todos.set(usize::from(*ref_prod_i), true);
                     }
                 }
@@ -194,9 +194,9 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = Vob::from_elem(grm.terms_len(), false);
+        let mut la = Vob::from_elem(grm.terms_len() as usize, false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], (0 as u32).into(), &la);
         let cls_is = is.close(&grm, &firsts);
         println!("{:?}", cls_is);
         assert_eq!(cls_is.items.len(), 6);
@@ -228,9 +228,9 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = Vob::from_elem(grm.terms_len(), false);
+        let mut la = Vob::from_elem(grm.terms_len() as usize, false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], (0 as u32).into(), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
         state_exists(&grm, &cls_is, "^", 0, 0, vec!["$"]);
@@ -239,7 +239,7 @@ mod test {
         state_exists(&grm, &cls_is, "S", 2, 0, vec!["b", "$"]);
 
         is = Itemset::new(&grm);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("F").unwrap())[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("F").unwrap())[0], (0 as u32).into(), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "F", 0, 0, vec!["$"]);
         state_exists(&grm, &cls_is, "C", 0, 0, vec!["d", "f"]);
@@ -270,9 +270,9 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = Vob::from_elem(grm.terms_len(), false);
+        let mut la = Vob::from_elem(grm.terms_len() as usize, false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], (0 as u32).into(), &la);
         let mut cls_is = is.close(&grm, &firsts);
 
         state_exists(&grm, &cls_is, "^", 0, 0, vec!["$"]);
@@ -280,19 +280,19 @@ mod test {
         state_exists(&grm, &cls_is, "S", 1, 0, vec!["b", "$"]);
 
         is = Itemset::new(&grm);
-        la = Vob::from_elem(grm.terms_len(), false);
+        la = Vob::from_elem(grm.terms_len() as usize, false);
         la.set(usize::from(grm.term_idx("b").unwrap()), true);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("S").unwrap())[1], 1.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("S").unwrap())[1], (1 as u32).into(), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "A", 0, 0, vec!["a"]);
         state_exists(&grm, &cls_is, "A", 1, 0, vec!["a"]);
         state_exists(&grm, &cls_is, "A", 2, 0, vec!["a"]);
 
         is = Itemset::new(&grm);
-        la = Vob::from_elem(grm.terms_len(), false);
+        la = Vob::from_elem(grm.terms_len() as usize, false);
         la.set(usize::from(grm.term_idx("a").unwrap()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("A").unwrap())[0], 1.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("A").unwrap())[0], (1 as u32).into(), &la);
         cls_is = is.close(&grm, &firsts);
         state_exists(&grm, &cls_is, "S", 0, 0, vec!["b", "c"]);
         state_exists(&grm, &cls_is, "S", 1, 0, vec!["b", "c"]);
@@ -304,9 +304,9 @@ mod test {
         let firsts = Firsts::new(&grm);
 
         let mut is = Itemset::new(&grm);
-        let mut la = Vob::from_elem(grm.terms_len(), false);
+        let mut la = Vob::from_elem(grm.terms_len() as usize, false);
         la.set(usize::from(grm.eof_term_idx()), true);
-        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], 0.into(), &la);
+        is.add(grm.nonterm_to_prods(grm.nonterm_idx("^").unwrap())[0], (0 as u32).into(), &la);
         let cls_is = is.close(&grm, &firsts);
 
         let goto1 = cls_is.goto(&grm, &Symbol::Nonterm(grm.nonterm_idx("S").unwrap()));

--- a/src/lib/pager.rs
+++ b/src/lib/pager.rs
@@ -270,11 +270,11 @@ pub fn pager_stategraph(grm: &YaccGrammar) -> StateGraph {
                 None    => {
                     match sym {
                         Symbol::Nonterm(nonterm_i) =>
-                            cnd_nonterm_weaklies[usize::from(nonterm_i)].push(StIdx(core_states.len())),
+                            cnd_nonterm_weaklies[usize::from(nonterm_i)].push(core_states.len().into()),
                         Symbol::Term(term_i) =>
-                            cnd_term_weaklies[usize::from(term_i)].push(StIdx(core_states.len())),
+                            cnd_term_weaklies[usize::from(term_i)].push(core_states.len().into())
                     }
-                    edges[state_i].insert(sym, StIdx(core_states.len()));
+                    edges[state_i].insert(sym, core_states.len().into());
                     edges.push(HashMap::new());
                     closed_states.push(None);
                     core_states.push(nstate);
@@ -304,7 +304,7 @@ fn gc(mut states: Vec<(Itemset, Itemset)>, mut edges: Vec<HashMap<Symbol, StIdx>
     // First of all, do a simple pass over all states. All state indexes reachable from the
     // start state will be inserted into the 'seen' set.
     let mut todo = HashSet::new();
-    todo.insert(StIdx(0));
+    todo.insert(StIdx::from(0 as u32));
     let mut seen = HashSet::new();
     while !todo.is_empty() {
         // XXX This is the clumsy way we're forced to do what we'd prefer to be:
@@ -337,8 +337,10 @@ fn gc(mut states: Vec<(Itemset, Itemset)>, mut edges: Vec<HashMap<Symbol, StIdx>
     let mut gc_states = Vec::with_capacity(seen.len());
     let mut offsets   = Vec::with_capacity(states.len());
     let mut offset    = 0;
-    for (state_i, zstate) in states.drain(..).enumerate().map(|(x, y)| (StIdx(x), y)) {
-        offsets.push(StIdx(usize::from(state_i) - offset));
+    for (state_i, zstate) in states.drain(..)
+                                   .enumerate()
+                                   .map(|(x, y)| (StIdx::from(x), y)) {
+        offsets.push(StIdx::from(usize::from(state_i) - offset));
         if !seen.contains(&state_i) {
             offset += 1;
             continue;
@@ -349,7 +351,9 @@ fn gc(mut states: Vec<(Itemset, Itemset)>, mut edges: Vec<HashMap<Symbol, StIdx>
     // At this point the offsets list will be [0, 1, 1]. We now create new edges where each
     // offset is corrected by looking it up in the offsets list.
     let mut gc_edges = Vec::with_capacity(seen.len());
-    for (st_edge_i, st_edges) in edges.drain(..).enumerate().map(|(x, y)| (StIdx(x), y)) {
+    for (st_edge_i, st_edges) in edges.drain(..)
+                                      .enumerate()
+                                      .map(|(x, y)| (StIdx::from(x), y)) {
         if !seen.contains(&st_edge_i) {
             continue;
         }
@@ -421,12 +425,12 @@ mod test {
         assert_eq!(sg.all_states_len(), 10);
         assert_eq!(sg.all_edges_len(), 10);
 
-        assert_eq!(sg.closed_state(StIdx::from(0)).items.len(), 3);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0)), "^", 0, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0)), "S", 0, 0, vec!["$", "b"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0)), "S", 1, 0, vec!["$", "b"]);
+        assert_eq!(sg.closed_state(StIdx::from(0 as u32)).items.len(), 3);
+        state_exists(&grm, &sg.closed_state(StIdx::from(0 as u32)), "^", 0, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx::from(0 as u32)), "S", 0, 0, vec!["$", "b"]);
+        state_exists(&grm, &sg.closed_state(StIdx::from(0 as u32)), "S", 1, 0, vec!["$", "b"]);
 
-        let s1 = sg.edge(StIdx::from(0), Symbol::Nonterm(grm.nonterm_idx("S").unwrap())).unwrap();
+        let s1 = sg.edge(StIdx::from(0 as u32), Symbol::Nonterm(grm.nonterm_idx("S").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s1).items.len(), 2);
         state_exists(&grm, &sg.closed_state(s1), "^", 0, 1, vec!["$"]);
         state_exists(&grm, &sg.closed_state(s1), "S", 0, 1, vec!["$", "b"]);
@@ -435,7 +439,7 @@ mod test {
         assert_eq!(sg.closed_state(s2).items.len(), 1);
         state_exists(&grm, &sg.closed_state(s2), "S", 0, 2, vec!["$", "b"]);
 
-        let s3 = sg.edge(StIdx::from(0), Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
+        let s3 = sg.edge(StIdx::from(0 as u32), Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s3).items.len(), 4);
         state_exists(&grm, &sg.closed_state(s3), "S", 1, 1, vec!["$", "b", "c"]);
         state_exists(&grm, &sg.closed_state(s3), "A", 0, 0, vec!["a"]);
@@ -497,16 +501,16 @@ mod test {
         assert_eq!(sg.all_edges_len(), 27);
 
         // State 0
-        assert_eq!(sg.closed_state(StIdx::from(0)).items.len(), 7);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0)), "^", 0, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0)), "X", 0, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0)), "X", 1, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0)), "X", 2, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0)), "X", 3, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0)), "X", 4, 0, vec!["$"]);
-        state_exists(&grm, &sg.closed_state(StIdx::from(0)), "X", 5, 0, vec!["$"]);
+        assert_eq!(sg.closed_state(StIdx::from(0 as u32)).items.len(), 7);
+        state_exists(&grm, &sg.closed_state(StIdx::from(0 as u32)), "^", 0, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx::from(0 as u32)), "X", 0, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx::from(0 as u32)), "X", 1, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx::from(0 as u32)), "X", 2, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx::from(0 as u32)), "X", 3, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx::from(0 as u32)), "X", 4, 0, vec!["$"]);
+        state_exists(&grm, &sg.closed_state(StIdx::from(0 as u32)), "X", 5, 0, vec!["$"]);
 
-        let s1 = sg.edge(StIdx::from(0), Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
+        let s1 = sg.edge(StIdx::from(0 as u32), Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s1).items.len(), 7);
         state_exists(&grm, &sg.closed_state(s1), "X", 0, 1, vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.closed_state(s1), "X", 1, 1, vec!["a", "d", "e", "$"]);
@@ -516,7 +520,7 @@ mod test {
         state_exists(&grm, &sg.closed_state(s1), "Z", 0, 0, vec!["c"]);
         state_exists(&grm, &sg.closed_state(s1), "T", 0, 0, vec!["a", "d", "e", "$"]);
 
-        let s7 = sg.edge(StIdx::from(0), Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
+        let s7 = sg.edge(StIdx::from(0 as u32), Symbol::Term(grm.term_idx("b").unwrap())).unwrap();
         assert_eq!(sg.closed_state(s7).items.len(), 7);
         state_exists(&grm, &sg.closed_state(s7), "X", 3, 1, vec!["a", "d", "e", "$"]);
         state_exists(&grm, &sg.closed_state(s7), "X", 4, 1, vec!["a", "d", "e", "$"]);
@@ -577,7 +581,7 @@ mod test {
         // Ommitted successors from the graph in Fig.3
 
         // X-successor of S0
-        let s0x = sg.edge(StIdx::from(0), Symbol::Nonterm(grm.nonterm_idx("X").unwrap())).unwrap();
+        let s0x = sg.edge(StIdx::from(0 as u32), Symbol::Nonterm(grm.nonterm_idx("X").unwrap())).unwrap();
         state_exists(&grm, &sg.closed_state(s0x), "^", 0, 1, vec!["$"]);
 
         // Y-successor of S1 (and it's d-successor)
@@ -645,7 +649,7 @@ mod test {
         let sg = pager_stategraph(&grm);
 
         // State 0
-        assert_eq!(sg.core_state(StIdx::from(0)).items.len(), 1);
-        state_exists(&grm, &sg.core_state(StIdx::from(0)), "^", 0, 0, vec!["$"]);
+        assert_eq!(sg.core_state(StIdx::from(0 as u32)).items.len(), 1);
+        state_exists(&grm, &sg.core_state(StIdx::from(0 as u32)), "^", 0, 0, vec!["$"]);
     }
 }

--- a/src/lib/pager.rs
+++ b/src/lib/pager.rs
@@ -155,23 +155,23 @@ pub fn pager_stategraph(grm: &YaccGrammar) -> StateGraph {
     let mut edges: Vec<HashMap<Symbol, StIdx>> = Vec::new();
 
     let mut state0 = Itemset::new(grm);
-    let mut ctx = Vob::from_elem(grm.terms_len(), false);
+    let mut ctx = Vob::from_elem(grm.terms_len() as usize, false);
     ctx.set(usize::from(grm.eof_term_idx()), true);
-    state0.add(grm.start_prod(), SIdx::from(0), &ctx);
+    state0.add(grm.start_prod(), SIdx::from(0 as u32), &ctx);
     closed_states.push(None);
     core_states.push(state0);
     edges.push(HashMap::new());
 
     // We maintain two lists of which nonterms and terms we've seen; when processing a given
     // state there's no point processing a nonterm or term more than once.
-    let mut seen_nonterms = Vob::from_elem(grm.nonterms_len(), false);
-    let mut seen_terms = Vob::from_elem(grm.terms_len(), false);
+    let mut seen_nonterms = Vob::from_elem(grm.nonterms_len() as usize, false);
+    let mut seen_terms = Vob::from_elem(grm.terms_len() as usize, false);
     // new_states is used to separate out iterating over states vs. mutating it
     let mut new_states = Vec::new();
     // cnd_[nonterm|term]_weaklies represent which states are possible weakly compatible
     // matches for a given symbol.
-    let mut cnd_nonterm_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(grm.nonterms_len());
-    let mut cnd_term_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(grm.terms_len());
+    let mut cnd_nonterm_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(grm.nonterms_len() as usize);
+    let mut cnd_term_weaklies: Vec<Vec<StIdx>> = Vec::with_capacity(grm.terms_len() as usize);
     for _ in 0..grm.terms_len() + 1 { cnd_term_weaklies.push(Vec::new()); }
     for _ in 0..grm.nonterms_len() { cnd_nonterm_weaklies.push(Vec::new()); }
 

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -200,7 +200,7 @@ pub fn state_exists(grm: &YaccGrammar, is: &Itemset, nt: &str, prod_off: usize, 
 
     let ab_prod_off = grm.nonterm_to_prods(grm.nonterm_idx(nt).unwrap())[prod_off];
     let ctx = &is.items[&(ab_prod_off, dot.into())];
-    for i in 0..grm.terms_len() {
+    for i in 0..grm.terms_len() as usize {
         let bit = ctx[i];
         let mut found = false;
         for t in la.iter() {

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -248,7 +248,7 @@ mod test {
         assert_eq!(sg.all_edges_len(), 9);
 
         // This follows the (not particularly logical) ordering of state numbers in the paper.
-        let s0 = StIdx(0);
+        let s0 = StIdx::from(0 as u32);
         sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("A").unwrap())).unwrap(); // s1
         let s2 = sg.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
         let s3 = sg.edge(s0, Symbol::Term(grm.term_idx("b").unwrap())).unwrap();

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -103,7 +103,9 @@ impl StateTable {
         let mut shift_reduce  = 0; // How many automatically resolved shift/reduces were made?
         let mut final_state = None;
 
-        for (state_i, state) in sg.iter_closed_states().enumerate().map(|(x, y)| (StIdx(x), y)) {
+        for (state_i, state) in sg.iter_closed_states()
+                                  .enumerate()
+                                  .map(|(x, y)| (StIdx::from(x), y)) {
             // Populate reduce and accepts
             for (&(prod_i, dot), ctx) in &state.items {
                 if dot < SIdx::from(grm.prod(prod_i).len()) {
@@ -307,7 +309,7 @@ mod test {
         let sg = pager_stategraph(&grm);
         assert_eq!(sg.all_states_len(), 9);
 
-        let s0 = StIdx(0);
+        let s0 = StIdx::from(0 as u32);
         let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s2 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Term").unwrap())).unwrap();
         let s3 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Factor").unwrap())).unwrap();
@@ -375,7 +377,7 @@ mod test {
         assert_eq!(st.actions.len(), 8);
 
         // We only extract the states necessary to test those rules affected by the reduce/reduce.
-        let s0 = StIdx(0);
+        let s0 = StIdx::from(0 as u32);
         let s4 = sg.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
 
         assert_eq!(st.action(s4,
@@ -396,7 +398,7 @@ mod test {
         let st = StateTable::new(&grm, &sg).unwrap();
         assert_eq!(st.actions.len(), 15);
 
-        let s0 = StIdx(0);
+        let s0 = StIdx::from(0 as u32);
         let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
@@ -425,7 +427,7 @@ mod test {
         let st = StateTable::new(&grm, &sg).unwrap();
         assert_eq!(st.actions.len(), 15);
 
-        let s0 = StIdx(0);
+        let s0 = StIdx::from(0 as u32);
         let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
@@ -470,7 +472,7 @@ mod test {
         let st = StateTable::new(&grm, &sg).unwrap();
         assert_eq!(st.actions.len(), 24);
 
-        let s0 = StIdx(0);
+        let s0 = StIdx::from(0 as u32);
         let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();
@@ -538,7 +540,7 @@ mod test {
         let st = StateTable::new(&grm, &sg).unwrap();
         assert_eq!(st.actions.len(), 34);
 
-        let s0 = StIdx(0);
+        let s0 = StIdx::from(0 as u32);
         let s1 = sg.edge(s0, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s3 = sg.edge(s1, Symbol::Term(grm.term_idx("+").unwrap())).unwrap();
         let s4 = sg.edge(s1, Symbol::Term(grm.term_idx("*").unwrap())).unwrap();

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -34,7 +34,7 @@ use std::collections::hash_map::{Entry, HashMap, OccupiedEntry};
 use std::hash::BuildHasherDefault;
 use std::fmt;
 
-use cfgrammar::{Grammar, PIdx, NTIdx, Symbol, TIdx};
+use cfgrammar::{Grammar, PIdx, NTIdx, SIdx, Symbol, TIdx};
 use cfgrammar::yacc::{AssocKind, YaccGrammar};
 use fnv::FnvHasher;
 
@@ -77,7 +77,7 @@ pub struct StateTable {
     // is represented as a hashtable {0: shift 1, 2: shift 0, 3: reduce 4}.
     actions          : HashMap<usize, Action, BuildHasherDefault<FnvHasher>>,
     gotos            : HashMap<(StIdx, NTIdx), StIdx>,
-    terms_len        : usize,
+    terms_len        : u32,
     /// The number of reduce/reduce errors encountered.
     pub reduce_reduce: u64,
     /// The number of shift/reduce errors encountered.
@@ -106,7 +106,7 @@ impl StateTable {
         for (state_i, state) in sg.iter_closed_states().enumerate().map(|(x, y)| (StIdx(x), y)) {
             // Populate reduce and accepts
             for (&(prod_i, dot), ctx) in &state.items {
-                if dot < grm.prod(prod_i).len().into() {
+                if dot < SIdx::from(grm.prod(prod_i).len()) {
                     continue;
                 }
                 for (term_i, _) in ctx.iter().enumerate().filter(|&(_, x)| x) {
@@ -217,8 +217,8 @@ impl StateTable {
         self.gotos.get(&(state_idx, nonterm_idx)).map_or(None, |x| Some(*x))
     }
 
-    fn actions_offset(terms_len: usize, state_idx: StIdx, term_idx: TIdx) -> usize {
-        usize::from(state_idx) * terms_len + usize::from(term_idx)
+    fn actions_offset(terms_len: u32, state_idx: StIdx, term_idx: TIdx) -> usize {
+        usize::from(state_idx) * terms_len as usize + usize::from(term_idx)
     }
 }
 
@@ -378,7 +378,9 @@ mod test {
         let s0 = StIdx(0);
         let s4 = sg.edge(s0, Symbol::Term(grm.term_idx("a").unwrap())).unwrap();
 
-        assert_eq!(st.action(s4, Symbol::Term(grm.term_idx("x").unwrap())).unwrap(), Action::Reduce(3.into()));
+        assert_eq!(st.action(s4,
+                             Symbol::Term(grm.term_idx("x").unwrap())).unwrap(),
+                             Action::Reduce((3 as u32).into()));
     }
 
     #[test]
@@ -430,13 +432,25 @@ mod test {
         let s5 = sg.edge(s4, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s6 = sg.edge(s3, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
 
-        assert_eq!(st.action(s5, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s5, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s5, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s5,
+                             Symbol::Term(grm.term_idx("+").unwrap())).unwrap(),
+                             Action::Reduce((2 as u32).into()));
+        assert_eq!(st.action(s5,
+                             Symbol::Term(grm.term_idx("*").unwrap())).unwrap(),
+                             Action::Reduce((2 as u32).into()));
+        assert_eq!(st.action(s5,
+                             Symbol::Term(grm.eof_term_idx())).unwrap(),
+                             Action::Reduce((2 as u32).into()));
 
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s6, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s6,
+                             Symbol::Term(grm.term_idx("+").unwrap())).unwrap(),
+                             Action::Reduce((1 as u32).into()));
+        assert_eq!(st.action(s6,
+                             Symbol::Term(grm.term_idx("*").unwrap())).unwrap(),
+                             Action::Shift(s4));
+        assert_eq!(st.action(s6,
+                             Symbol::Term(grm.eof_term_idx())).unwrap(),
+                             Action::Reduce((1 as u32).into()));
     }
 
     #[test]
@@ -465,20 +479,44 @@ mod test {
         let s7 = sg.edge(s4, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s8 = sg.edge(s3, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
 
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Shift(s3));
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s6, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Shift(s5));
-        assert_eq!(st.action(s6, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(3.into()));
+        assert_eq!(st.action(s6,
+                             Symbol::Term(grm.term_idx("+").unwrap())).unwrap(),
+                             Action::Shift(s3));
+        assert_eq!(st.action(s6,
+                             Symbol::Term(grm.term_idx("*").unwrap())).unwrap(),
+                             Action::Shift(s4));
+        assert_eq!(st.action(s6,
+                             Symbol::Term(grm.term_idx("=").unwrap())).unwrap(),
+                             Action::Shift(s5));
+        assert_eq!(st.action(s6,
+                             Symbol::Term(grm.eof_term_idx())).unwrap(),
+                             Action::Reduce((3 as u32).into()));
 
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s7,
+                             Symbol::Term(grm.term_idx("+").unwrap())).unwrap(),
+                             Action::Reduce((2 as u32).into()));
+        assert_eq!(st.action(s7,
+                             Symbol::Term(grm.term_idx("*").unwrap())).unwrap(),
+                             Action::Reduce((2 as u32).into()));
+        assert_eq!(st.action(s7,
+                             Symbol::Term(grm.term_idx("=").unwrap())).unwrap(),
+                             Action::Reduce((2 as u32).into()));
+        assert_eq!(st.action(s7,
+                             Symbol::Term(grm.eof_term_idx())).unwrap(),
+                             Action::Reduce((2 as u32).into()));
 
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s8, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s8,
+                             Symbol::Term(grm.term_idx("+").unwrap())).unwrap(),
+                             Action::Reduce((1 as u32).into()));
+        assert_eq!(st.action(s8,
+                             Symbol::Term(grm.term_idx("*").unwrap())).unwrap(),
+                             Action::Shift(s4));
+        assert_eq!(st.action(s8,
+                             Symbol::Term(grm.term_idx("=").unwrap())).unwrap(),
+                             Action::Reduce((1 as u32).into()));
+        assert_eq!(st.action(s8,
+                             Symbol::Term(grm.eof_term_idx())).unwrap(),
+                             Action::Reduce((1 as u32).into()));
     }
 
     #[test]
@@ -511,28 +549,66 @@ mod test {
         let s9 = sg.edge(s4, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
         let s10 = sg.edge(s3, Symbol::Nonterm(grm.nonterm_idx("Expr").unwrap())).unwrap();
 
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(4.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Reduce(4.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Reduce(4.into()));
-        assert_eq!(st.action(s7, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(4.into()));
+        assert_eq!(st.action(s7,
+                             Symbol::Term(grm.term_idx("+").unwrap())).unwrap(),
+                             Action::Reduce((4 as u32).into()));
+        assert_eq!(st.action(s7,
+                             Symbol::Term(grm.term_idx("*").unwrap())).unwrap(),
+                             Action::Reduce((4 as u32).into()));
+        assert_eq!(st.action(s7,
+                             Symbol::Term(grm.term_idx("=").unwrap())).unwrap(),
+                             Action::Reduce((4 as u32).into()));
+        assert_eq!(st.action(s7,
+                             Symbol::Term(grm.eof_term_idx())).unwrap(),
+                             Action::Reduce((4 as u32).into()));
 
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Shift(s3));
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Shift(s5));
-        assert_eq!(st.action(s8, Symbol::Term(grm.term_idx("~").unwrap())).unwrap(), Action::Shift(s6));
-        assert_eq!(st.action(s8, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(3.into()));
+        assert_eq!(st.action(s8,
+                             Symbol::Term(grm.term_idx("+").unwrap())).unwrap(),
+                             Action::Shift(s3));
+        assert_eq!(st.action(s8,
+                             Symbol::Term(grm.term_idx("*").unwrap())).unwrap(),
+                             Action::Shift(s4));
+        assert_eq!(st.action(s8,
+                             Symbol::Term(grm.term_idx("=").unwrap())).unwrap(),
+                             Action::Shift(s5));
+        assert_eq!(st.action(s8,
+                             Symbol::Term(grm.term_idx("~").unwrap())).unwrap(),
+                             Action::Shift(s6));
+        assert_eq!(st.action(s8,
+                             Symbol::Term(grm.eof_term_idx())).unwrap(),
+                             Action::Reduce((3 as u32).into()));
 
-        assert_eq!(st.action(s9, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s9, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s9, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Reduce(2.into()));
-        assert_eq!(st.action(s9, Symbol::Term(grm.term_idx("~").unwrap())).unwrap(), Action::Shift(s6));
-        assert_eq!(st.action(s9, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(2.into()));
+        assert_eq!(st.action(s9,
+                             Symbol::Term(grm.term_idx("+").unwrap())).unwrap(),
+                             Action::Reduce((2 as u32).into()));
+        assert_eq!(st.action(s9,
+                             Symbol::Term(grm.term_idx("*").unwrap())).unwrap(),
+                             Action::Reduce((2 as u32).into()));
+        assert_eq!(st.action(s9,
+                             Symbol::Term(grm.term_idx("=").unwrap())).unwrap(),
+                             Action::Reduce((2 as u32).into()));
+        assert_eq!(st.action(s9,
+                             Symbol::Term(grm.term_idx("~").unwrap())).unwrap(),
+                             Action::Shift(s6));
+        assert_eq!(st.action(s9,
+                             Symbol::Term(grm.eof_term_idx())).unwrap(),
+                             Action::Reduce((2 as u32).into()));
 
-        assert_eq!(st.action(s10, Symbol::Term(grm.term_idx("+").unwrap())).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s10, Symbol::Term(grm.term_idx("*").unwrap())).unwrap(), Action::Shift(s4));
-        assert_eq!(st.action(s10, Symbol::Term(grm.term_idx("=").unwrap())).unwrap(), Action::Reduce(1.into()));
-        assert_eq!(st.action(s10, Symbol::Term(grm.term_idx("~").unwrap())).unwrap(), Action::Shift(s6));
-        assert_eq!(st.action(s10, Symbol::Term(grm.eof_term_idx())).unwrap(), Action::Reduce(1.into()));
+        assert_eq!(st.action(s10,
+                             Symbol::Term(grm.term_idx("+").unwrap())).unwrap(),
+                             Action::Reduce((1 as u32).into()));
+        assert_eq!(st.action(s10,
+                             Symbol::Term(grm.term_idx("*").unwrap())).unwrap(),
+                             Action::Shift(s4));
+        assert_eq!(st.action(s10,
+                             Symbol::Term(grm.term_idx("=").unwrap())).unwrap(),
+                             Action::Reduce((1 as u32).into()));
+        assert_eq!(st.action(s10,
+                             Symbol::Term(grm.term_idx("~").unwrap())).unwrap(),
+                             Action::Shift(s6));
+        assert_eq!(st.action(s10,
+                             Symbol::Term(grm.eof_term_idx())).unwrap(),
+                             Action::Reduce((1 as u32).into()));
     }
 
     #[test]
@@ -546,7 +622,7 @@ D : D;
         match StateTable::new(&grm, &sg) {
             Ok(_) => panic!("Infinitely recursive rule let through"),
             Err(StateTableError{kind: StateTableErrorKind::AcceptReduceConflict, prod_idx})
-                if prod_idx == 1.into() => (),
+                if prod_idx == (1 as u32).into() => (),
             Err(e) => panic!("Incorrect error returned {}", e)
         }
     }


### PR DESCRIPTION
This PR moves lrtable to using `u32` instead of `usize`. It does this in three chunks to make reviewing a bit easier, though all three commits are semi-mechanical. [Note the middle commit doesn't replicate `cfgrammar`s macro, because we only have one u32-api-but-stores-u16-struct.]