### PR TITLE
Optimisations

### DIFF
--- a/src/lib/firsts.rs
+++ b/src/lib/firsts.rs
@@ -37,7 +37,7 @@ use cfgrammar::yacc::YaccGrammar;
 
 /// `Firsts` stores all the first sets for a given grammar. For example, given this code and
 /// grammar:
-/// ```
+/// ```ignore
 ///   let grm = yacc_grm(YaccKind::Original, "
 ///     S: A 'b';
 ///     A: 'a'
@@ -46,7 +46,7 @@ use cfgrammar::yacc::YaccGrammar;
 /// ```
 /// then the following assertions (and only the following assertions) about the firsts set are
 /// correct:
-/// ```
+/// ```ignore
 ///   assert!(firsts.is_set(grm.nonterm_idx("S").unwrap(), grm.term_idx("a").unwrap()));
 ///   assert!(firsts.is_set(grm.nonterm_idx("S").unwrap(), grm.term_idx("b").unwrap()));
 ///   assert!(firsts.is_set(grm.nonterm_idx("A").unwrap(), grm.term_idx("a").unwrap()));

--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -76,7 +76,7 @@ pub struct StateTable {
     //   1  shift 0  reduce B
     // is represented as a hashtable {0: shift 1, 2: shift 0, 3: reduce 4}.
     actions          : HashMap<u32, Action, BuildHasherDefault<FnvHasher>>,
-    gotos            : HashMap<u32, StIdx>,
+    gotos            : HashMap<u32, StIdx, BuildHasherDefault<FnvHasher>>,
     nonterms_len     : u32,
     terms_len        : u32,
     /// The number of reduce/reduce errors encountered.
@@ -99,7 +99,7 @@ pub enum Action {
 impl StateTable {
     pub fn new(grm: &YaccGrammar, sg: &StateGraph) -> Result<StateTable, StateTableError> {
         let mut actions = HashMap::with_hasher(BuildHasherDefault::<FnvHasher>::default());
-        let mut gotos   = HashMap::new();
+        let mut gotos   = HashMap::with_hasher(BuildHasherDefault::<FnvHasher>::default());
         let mut reduce_reduce = 0; // How many automatically resolved reduce/reduces were made?
         let mut shift_reduce  = 0; // How many automatically resolved shift/reduces were made?
         let mut final_state = None;


### PR DESCRIPTION
This small PR starts with two minor optimisations (slightly reducing memory usage) before introducing a more significant one (switching to using the FNV hasher, which is much more effective on small integers). It ends up with an unrelated doc test fix, which seems to have been tickled by an update in Rust.