### PR TITLE
Reflect cfgrammar out of order change

### DIFF
--- a/src/lib/statetable.rs
+++ b/src/lib/statetable.rs
@@ -126,6 +126,12 @@ impl StateTable {
                         Entry::Occupied(mut e) => {
                             match *e.get_mut() {
                                 Action::Reduce(prod_j) => {
+                                    if prod_i == grm.start_prod() && term_i == usize::from(grm.eof_term_idx()) {
+                                        return Err(StateTableError{
+                                            kind: StateTableErrorKind::AcceptReduceConflict,
+                                            prod_idx: prod_i
+                                        });
+                                    }
                                     // By default, Yacc resolves reduce/reduce conflicts in favour
                                     // of the earlier production in the grammar.
                                     if prod_i < prod_j {


### PR DESCRIPTION
[Needs https://github.com/softdevteam/cfgrammar/pull/23 to be merged first. Once that's merged, the tests in here will need kicking to ensure that the Cerecke test succeeds.]

This reflects the recent changes to cfgrammar. It means that we now deal correctly with less common examples such as that derived from Cerecke's PhD thesis.