### PR TITLE
Add helper functions to make error recovery faster.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ fnv = "1.0.5"
 macro-attr = "0.2.0"
 newtype_derive = "0.1.6"
 cfgrammar = { git = "https://github.com/softdevteam/cfgrammar" }
-vob = "0.1.0"
+vob = "1.0.0"

--- a/src/lib/itemset.rs
+++ b/src/lib/itemset.rs
@@ -107,7 +107,7 @@ impl Itemset {
                     dot = y;
                 }
                 None => {
-                    match zero_todos.iter_set_bits().next() {
+                    match zero_todos.iter_set_bits(..).next() {
                         Some(i) => prod_i = PIdx::from(i),
                         None => break
                     }

--- a/src/lib/stategraph.rs
+++ b/src/lib/stategraph.rs
@@ -146,7 +146,7 @@ impl StateGraph {
                 }
                 o.push_str(", {");
                 let mut seen_b = false;
-                for (b_idx, _) in ctx.iter().enumerate().filter(|&(_, x)| x) {
+                for b_idx in ctx.iter_set_bits(..) {
                     if seen_b {
                         o.push_str(", ");
                     } else {


### PR DESCRIPTION
NB: https://github.com/softdevteam/lrtable/pull/87 needs to be merged first. I might need to toggle the "base" above back to "master" and maybe do a rebase.


lrpar's error recovery functions spend a long time querying the statetable: that means lots of hash table lookups which, cumulatively, become very costly. This commit enables the recoverers to reduce the number of lookups.

There are a few related things in here:

  1) Use the new Range facility in Vob's iter_set_bits to speed up the existing
     state_actions function.

  2) Add a new helper function state_shifts which tells users only which entries
     are shifts (i.e. it won't tell you where reduces or accepts are). If you
     only care about searching for shifts, this saves a lot of hashtable
     lookups.

  3) Add a more esoteric helper function "core_reduces" which is best explained
     by the comment in the commit. This is specifically useful for the MF
     recoverer as it removes its dependency on the stategraph.

These make a big difference to the recoverers.

[FWIW, I also tried a very different approach, using an IndexMap which represented an ordered sparse table, and a separate list of where each state's entries were in that IndexMap. Perhaps because an IndexMap costs an extra lookup, I couldn't measure any difference when using this approach. It also uses a bit more memory, so I ended up marginally preferring the approach in this commit.]