### PR TITLE
Add "reduce_only_state".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: rust
-rust: nightly
+rust: nightly-2018-03-25


### PR DESCRIPTION
This allows us to test if a state 1) only contains reduce actions 2) each reduce action reduces to the same production.

We'll be using this in lrpar shortly (probably).